### PR TITLE
Use custom resource riseproject.com/runner for node scheduling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Trigger sample workflow
         if: steps.env.outputs.tag == 'staging'
         env:
-          GH_TOKEN: ${{ secrets.SAMPLE_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.RISCV_RUNNER_SAMPLE_ACCESS_TOKEN }}
+          GH_REPO: riseproject-dev/riscv-runner-app-sample
+          GH_WORKFLOW: hello.yml
         run: |
-          gh workflow run hello.yml --repo riseproject-dev/riscv-runner-app-sample
+          gh workflow run ${GH_WORKFLOW} --repo ${GH_REPO}
           sleep 5
-          gh run watch $(gh run list --repo riseproject-dev/riscv-runner-app-sample --workflow hello.yml --limit 1 --json databaseId --jq '.[0].databaseId') --repo riseproject-dev/riscv-runner-app-sample --exit-status
+          gh run watch $(gh run list --repo ${GH_REPO} --workflow ${GH_WORKFLOW} --limit 1 --json databaseId --jq '.[0].databaseId') --repo ${GH_REPO} --exit-status

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,3 +76,12 @@ jobs:
 
       - name: Health check
         run: python3 ./bin/check-health.py ${{ steps.env.outputs.tag == 'staging' && '--staging' || '' }}
+
+      - name: Trigger sample workflow
+        if: steps.env.outputs.tag == 'staging'
+        env:
+          GH_TOKEN: ${{ secrets.SAMPLE_REPO_TOKEN }}
+        run: |
+          gh workflow run hello.yml --repo riseproject-dev/riscv-runner-app-sample
+          sleep 5
+          gh run watch $(gh run list --repo riseproject-dev/riscv-runner-app-sample --workflow hello.yml --limit 1 --json databaseId --jq '.[0].databaseId') --repo riseproject-dev/riscv-runner-app-sample --exit-status

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 
 __pycache__/
 package/
+.venv/
 *.py[cod]
 *$py.class
 *.so

--- a/handler.py
+++ b/handler.py
@@ -283,7 +283,7 @@ def init_k8s_config():
         )
     return yaml.safe_load(kubeconfig)
 
-def provision_runner(jit_config, pod_name, k8s_image, k8s_spec):
+def provision_runner(payload, jit_config, pod_name, k8s_image, k8s_spec):
     """Provision a new runner in a Kubernetes pod."""
     with k8s.config.new_client_from_config_dict(init_k8s_config()) as client:
         api = k8s.client.CoreV1Api(client)
@@ -315,7 +315,9 @@ def provision_runner(jit_config, pod_name, k8s_image, k8s_spec):
         }
 
         api.create_namespaced_pod(body=pod_manifest, namespace=namespace)
-        logger.info("Provisioned runner pod %s in namespace %s (image=%s)", pod_name, namespace, image)
+        repo = payload.get("repository", {}).get("full_name")
+        job_url = payload.get("workflow_job", {}).get("html_url")
+        logger.info("Provisioned runner pod %s in namespace %s (image=%s) for repo=%s job=%s", pod_name, namespace, image, repo, job_url)
         return f"Pod {pod_name} created successfully."
 
 @app.route("/health", methods=['GET'])
@@ -331,4 +333,4 @@ def webhook():
     installation_token = authenticate_app_as_organization(payload)
     runner_group_id = ensure_runner_group(payload, installation_token)
     jit_config, pod_name = create_jit_runner_config(payload, installation_token, runner_group_id, job_labels)
-    return provision_runner(jit_config, pod_name, k8s_image, k8s_spec)
+    return provision_runner(payload, jit_config, pod_name, k8s_image, k8s_spec)

--- a/handler.py
+++ b/handler.py
@@ -106,16 +106,17 @@ def check_webhook_event(body):
         raise WebhookError(400, "Invalid JSON payload")
 
     action = payload.get("action")
-    if action != "queued":
+    if action not in ("queued", "completed"):
         logger.info("Ignoring action: %s", action)
         raise WebhookError(200, f"Ignoring action: {action}")
 
     job = payload.get("workflow_job", {})
-    logger.info("Received queued workflow_job id=%s name=%s repo=%s labels=%s",
-                job.get("id"), job.get("name"),
+    logger.info("Received %s workflow_job id=%s name=%s repo=%s labels=%s",
+                action, job.get("id"), job.get("name"),
                 payload.get("repository", {}).get("full_name"),
                 job.get("labels"))
-    return payload
+
+    return payload, action
 
 def check_required_labels(payload):
     """Check that the workflow job has the required runs-on labels."""
@@ -248,7 +249,7 @@ def create_jit_runner_config(payload, installation_token, runner_group_id, job_l
     if not job_id:
         raise WebhookError(400, "Missing workflow_job id in payload")
 
-    pod_name = f"rise-riscv-runner-workflow-{job_id}-{int(time.time())}"
+    pod_name = f"rise-riscv-runner-workflow-{job_id}"
 
     headers = {
         "Authorization": f"Bearer {installation_token}",
@@ -288,7 +289,6 @@ def provision_runner(payload, jit_config, pod_name, k8s_image, k8s_spec):
     with k8s.config.new_client_from_config_dict(init_k8s_config()) as client:
         api = k8s.client.CoreV1Api(client)
 
-        namespace = os.environ.get("K8S_NAMESPACE", "default")
         image = os.environ.get("RUNNER_IMAGE", k8s_image)
 
         pod_manifest = {
@@ -314,11 +314,33 @@ def provision_runner(payload, jit_config, pod_name, k8s_image, k8s_spec):
             }
         }
 
-        api.create_namespaced_pod(body=pod_manifest, namespace=namespace)
+        api.create_namespaced_pod(body=pod_manifest, namespace="default")
         repo = payload.get("repository", {}).get("full_name")
         job_url = payload.get("workflow_job", {}).get("html_url")
-        logger.info("Provisioned runner pod %s in namespace %s (image=%s) for repo=%s job=%s", pod_name, namespace, image, repo, job_url)
+        logger.info("Provisioned runner pod %s for repo=%s, image=%s, job=%s", pod_name, repo, image, job_url)
         return f"Pod {pod_name} created successfully."
+
+def delete_runner(payload):
+    """Delete a runner pod for a cancelled workflow job."""
+    job_id = payload.get("workflow_job", {}).get("id")
+    if not job_id:
+        raise WebhookError(400, "Missing workflow_job id in payload")
+
+    pod_name = f"rise-riscv-runner-workflow-{job_id}"
+
+    with k8s.config.new_client_from_config_dict(init_k8s_config()) as client:
+        api = k8s.client.CoreV1Api(client)
+        try:
+            api.delete_namespaced_pod(name=pod_name, namespace="default")
+            repo = payload.get("repository", {}).get("full_name")
+            job_url = payload.get("workflow_job", {}).get("html_url")
+            logger.info("Deleted runner pod %s for repo=%s, job=%s", pod_name, repo, job_url)
+            return f"Pod {pod_name} deleted successfully."
+        except k8s.client.exceptions.ApiException as e:
+            if e.status == 404:
+                logger.info("Pod %s not found, already deleted", pod_name)
+                return f"Pod {pod_name} not found."
+            raise
 
 @app.route("/health", methods=['GET'])
 def health():
@@ -327,10 +349,18 @@ def health():
 @app.route("/", methods=['POST'])
 def webhook():
     body = check_webhook_signature(request.headers, request.get_data(as_text=True))
-    payload = check_webhook_event(body)
-    k8s_image, k8s_spec, job_labels = check_required_labels(payload)
-    authorize_organization(payload)
-    installation_token = authenticate_app_as_organization(payload)
-    runner_group_id = ensure_runner_group(payload, installation_token)
-    jit_config, pod_name = create_jit_runner_config(payload, installation_token, runner_group_id, job_labels)
-    return provision_runner(payload, jit_config, pod_name, k8s_image, k8s_spec)
+    payload, action = check_webhook_event(body)
+
+    if action == "queued":
+        k8s_image, k8s_spec, job_labels = check_required_labels(payload)
+        authorize_organization(payload)
+        installation_token = authenticate_app_as_organization(payload)
+        runner_group_id = ensure_runner_group(payload, installation_token)
+        jit_config, pod_name = create_jit_runner_config(payload, installation_token, runner_group_id, job_labels)
+        return provision_runner(payload, jit_config, pod_name, k8s_image, k8s_spec)
+    elif action == "completed":
+        return delete_runner(payload)
+    else:
+        logger.info("Ignoring {action} job")
+        raise WebhookError(200, f"Ignoring {action} job")
+

--- a/handler.py
+++ b/handler.py
@@ -141,19 +141,11 @@ def check_required_labels(payload):
         "nodeSelector": {
             "riseproject.dev/board": "scw-em-rv1",
         },
-        "resources": {
-            "requests": {
-                "cpu": "3000m", # The EM-RV1 board has 4 cores, but we leave some headroom for the kube-flannel and kube-proxy daemons
-            }
-        },
     }
     # SCW_EM_RV2_SPEC = {
     #     "nodeSelector": {
     #         "riseproject.dev/board": "scw-em-rv2",
     #     },
-    #     "resources": {
-    #         "cpu": "7000m",
-    #     }
     # }
 
     # Defaults to the Scaleway EM-RV1 board
@@ -311,7 +303,12 @@ def provision_runner(jit_config, pod_name, k8s_image, k8s_spec):
                     "command": ["/bin/bash", "-eux", "-o", "pipefail", "-c"],
                     "args": [
                         f"./run.sh --jitconfig {jit_config}"
-                    ]
+                    ],
+                    "resources": {
+                        "limits": {
+                            "riseproject.com/runner": "1",
+                        }
+                    }
                 }],
                 "restartPolicy": "Never"
             }

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -19,6 +19,7 @@ from handler import (
     ensure_runner_group,
     create_jit_runner_config,
     provision_runner,
+    delete_runner,
     compute_signature,
 )
 
@@ -49,11 +50,18 @@ def test_invalid_signature():
 
 def test_queued_event():
     body = '{"action":"queued"}'
-    payload = check_webhook_event(body)
+    payload, action = check_webhook_event(body)
+    assert action == "queued"
     assert payload["action"] == "queued"
 
+def test_completed_event():
+    body = '{"action":"completed","workflow_job":{"id":123}}'
+    payload, action = check_webhook_event(body)
+    assert action == "completed"
+    assert payload["action"] == "completed"
+
 def test_ignored_event():
-    body = '{"action":"completed"}'
+    body = '{"action":"in_progress"}'
     with pytest.raises(WebhookError) as exc:
         check_webhook_event(body)
     assert exc.value.status_code == 200
@@ -187,7 +195,7 @@ def test_create_jit_runner_config(requests_mock):
 
     jit_config, pod_name = create_jit_runner_config(payload, installation_token, runner_group_id, ["rise", "ubuntu-24.04-riscv"])
     assert jit_config == "base64-encoded-jit-config-string"
-    assert pod_name.startswith("rise-riscv-runner-workflow-12345-")
+    assert pod_name == "rise-riscv-runner-workflow-12345"
 
 @patch('handler.init_k8s_config', return_value={})
 @patch('handler.k8s.config.new_client_from_config_dict')
@@ -248,3 +256,49 @@ def test_provision_runner_api_exception(mock_create_client, mock_init_config):
     with pytest.raises(Exception) as excinfo:
         provision_runner({}, "jit-config", "test-pod", "img", {})
     assert "Test API Error" == str(excinfo.value)
+
+@patch('handler.init_k8s_config', return_value={})
+@patch('handler.k8s.config.new_client_from_config_dict')
+@patch('handler.k8s.client.CoreV1Api')
+def test_delete_runner_success(mock_core_v1_api, mock_create_client, mock_init_config):
+    """Test successful deletion of a cancelled runner pod."""
+    mock_api_client = MagicMock()
+    mock_create_client.return_value = mock_api_client
+    mock_api_client.__enter__ = MagicMock(return_value=mock_api_client)
+    mock_api_client.__exit__ = MagicMock(return_value=False)
+
+    mock_api_instance = MagicMock()
+    mock_core_v1_api.return_value = mock_api_instance
+
+    payload = {
+        "workflow_job": {"id": 12345, "conclusion": "cancelled", "html_url": "https://github.com/org/repo/actions/runs/1/job/12345"},
+        "repository": {"full_name": "riseproject-dev/sample"},
+    }
+
+    result = delete_runner(payload)
+    assert "deleted successfully" in result
+    mock_api_instance.delete_namespaced_pod.assert_called_once_with(
+        name="rise-riscv-runner-workflow-12345", namespace="default"
+    )
+
+@patch('handler.init_k8s_config', return_value={})
+@patch('handler.k8s.config.new_client_from_config_dict')
+@patch('handler.k8s.client.CoreV1Api')
+def test_delete_runner_not_found(mock_core_v1_api, mock_create_client, mock_init_config):
+    """Test deletion when pod is already gone."""
+    mock_api_client = MagicMock()
+    mock_create_client.return_value = mock_api_client
+    mock_api_client.__enter__ = MagicMock(return_value=mock_api_client)
+    mock_api_client.__exit__ = MagicMock(return_value=False)
+
+    mock_api_instance = MagicMock()
+    mock_core_v1_api.return_value = mock_api_instance
+    mock_api_instance.delete_namespaced_pod.side_effect = kubernetes.client.exceptions.ApiException(status=404)
+
+    payload = {
+        "workflow_job": {"id": 12345, "conclusion": "cancelled"},
+        "repository": {"full_name": "riseproject-dev/sample"},
+    }
+
+    result = delete_runner(payload)
+    assert "not found" in result

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -207,7 +207,11 @@ def test_provision_runner_success(mock_core_v1_api, mock_create_client, mock_ini
     os.environ["K8S_NAMESPACE"] = "test-namespace"
     os.environ["RUNNER_IMAGE"] = "test-runner-image:latest"
 
-    result = provision_runner(jit_config, pod_name, "test-runner-image:latest", {"nodeSelector": {}})
+    payload = {
+        "repository": {"full_name": "riseproject-dev/sample"},
+        "workflow_job": {"html_url": "https://github.com/riseproject-dev/sample/actions/runs/1/job/1"},
+    }
+    result = provision_runner(payload, jit_config, pod_name, "test-runner-image:latest", {"nodeSelector": {}})
     assert "created successfully" in result
 
     mock_core_v1_api.assert_called_once()
@@ -231,7 +235,7 @@ def test_provision_runner_config_exception():
     saved = os.environ.pop("K8S_KUBECONFIG", None)
     try:
         with pytest.raises(kubernetes.config.ConfigException):
-            provision_runner("jit-config", "test-pod", "img", {})
+            provision_runner({}, "jit-config", "test-pod", "img", {})
     finally:
         if saved is not None:
             os.environ["K8S_KUBECONFIG"] = saved
@@ -242,5 +246,5 @@ def test_provision_runner_config_exception():
 def test_provision_runner_api_exception(mock_create_client, mock_init_config):
     """Test runner provisioning failure due to a generic API error."""
     with pytest.raises(Exception) as excinfo:
-        provision_runner("jit-config", "test-pod", "img", {})
+        provision_runner({}, "jit-config", "test-pod", "img", {})
     assert "Test API Error" == str(excinfo.value)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -222,6 +222,7 @@ def test_provision_runner_success(mock_core_v1_api, mock_create_client, mock_ini
     assert len(args) == 1
     assert "--jitconfig" in args[0]
     assert jit_config in args[0]
+    assert pod_manifest['spec']['containers'][0]['resources'] == {"limits": {"riseproject.com/runner": "1"}}
 
 def test_provision_runner_config_exception():
     """Test runner provisioning failure due to missing K8S_KUBECONFIG."""


### PR DESCRIPTION
Replace per-board CPU requests with a custom extended resource to enforce one runner per node. Add test assertion for the resource.