### PR TITLE
Added Label for Milk-V Pioneer box

### DIFF
--- a/container/handler.py
+++ b/container/handler.py
@@ -168,6 +168,13 @@ def match_labels_to_k8s(org_id, job_labels):
         return "scw-em-rv1", RUNNER_IMAGE_UBUNTU_26_04
     elif job_labels == ["ubuntu-26.04-riscv-rvv"]:
         return "cloudv10x-rvv", RUNNER_IMAGE_UBUNTU_26_04
+    elif job_labels == ["ubuntu-24.04-riscv-2xlarge"]:
+        return "cloudv10x-pioneer", RUNNER_IMAGE_UBUNTU_24_04 # TODO: Later we will have to add other 
+                                                              # providers aside from cloud-v too and we 
+                                                              # need to think if we are going to restrict 2x 
+                                                              # large to Milk-V Pioneer box or there can be other 
+                                                              # RISC-V machines with, for example,  in the 
+                                                              # future under this label
     # Special case(s) for PyTorch org
     elif org_id == PYTORCH_ORG_ID and job_labels == ["linux.riscv64"]:
         return "scw-em-rv1", RUNNER_IMAGE_UBUNTU_24_04

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -109,6 +109,11 @@ def test_match_labels_rvv():
     k8s_pool, k8s_image = match_labels_to_k8s(0, ["ubuntu-24.04-riscv-rvv"])
     assert k8s_pool == "cloudv10x-rvv"
     assert k8s_image == "rg.fr-par.scw.cloud/funcscwriseriscvrunnerappqdvknz9s/riscv-runner:ubuntu-24.04-2.331.0"
+    
+def test_match_labels_2xlarge():
+    k8s_pool, k8s_image = match_labels_to_k8s(0, ["ubuntu-24.04-riscv-2xlarge"])
+    assert k8s_pool == "cloudv10x-pioneer"
+    assert k8s_image == "rg.fr-par.scw.cloud/funcscwriseriscvrunnerappqdvknz9s/riscv-runner:ubuntu-24.04-2.331.0"
 
 
 def test_match_labels_unsupported():


### PR DESCRIPTION
I have added a label for the Milk-V Pioneer box. Please check this out. I would like to test if the build can be scheduled on this node. I also remember you saying that we need to have some resource limit here. Is that anything I should be concerned about at this point? 

I think, for now 64 core is good enough, we can restrict the memory to 90Gi since usable memory on milkv pioneer box node is 121G