### PR TITLE
Split sync_workers_state into 5 phase functions and add coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,27 +17,33 @@ env:
   STAGING_URL: https://riseriscvrunnerappst73ndwr0w-ghfe.functions.fnc.fr-par.scw.cloud
 
 jobs:
-  resolve:
+  setup:
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.env.outputs.result }}
+      environment: ${{ steps.env.outputs.environment }}
     steps:
       - id: env
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "result=main" >> $GITHUB_OUTPUT
+            echo "environment=main" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
-            echo "result=staging" >> $GITHUB_OUTPUT
+            echo "environment=staging" >> $GITHUB_OUTPUT
           fi
 
   test:
     runs-on: ubuntu-latest
+    needs: [setup]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # diff-cover needs the base commit
+      - name: Setup Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-      - run: |
+      - name: Run tests
+        run: |
           python -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
@@ -45,12 +51,50 @@ jobs:
           pip install -r requirements-dev.txt
           PYTHONPATH=${{ github.workspace }}/container pytest
 
+      - name: Add diff coverage to step summary
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        run: |
+          if [[ "${{ github.event_name }}" = "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            BASE_REF_NAME="refs/heads/${{ github.event.pull_request.base.ref }}"
+            BASE_REF_URL="${{ github.event.pull_request.base.repo.html_url }}/tree/${BASE_SHA}"
+          elif [[ "${{ github.event_name }}" = "push" ]]; then
+            BASE_SHA="${{ github.event.before }}"
+            BASE_REF_NAME="${{ github.ref }}"
+            # First push to a branch reports 40 zeros — no base to diff against, skip.
+            if [[ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]]; then
+              if [[ -n "${{ needs.setup.outputs.environment }}" ]]; then
+                # If we are on main or staging, there _SHOULD_ be a `github.event.before`
+                echo "::error::.github/workflows/release.yml Branch ${{ github.ref_name}} SHOULD have a previous value, but github.event.before = ${{ github.event.before }}"
+                exit 0 # do not fail the workflow nonetheless
+              fi
+              # If we are not on main or staging, compare to staging
+              git fetch origin staging # Make sure origin/staging is available
+              BASE_SHA="$(git rev-parse origin/staging)"
+              BASE_REF_NAME="origin/staging"
+            fi
+            BASE_REF_URL="${{ github.event.repository.html_url }}/tree/${BASE_SHA}"
+          fi
+          if [[ -n "${BASE_SHA}" ]]; then
+            source .venv/bin/activate
+            diff-cover coverage.xml \
+              --compare-branch "${BASE_SHA}" \
+              --markdown-report diff-cover.md \
+              --fail-under 80
+            {
+              echo ""
+              echo "**Base ref: [${BASE_REF_NAME}](${BASE_REF_URL})**"
+              echo ""
+              cat diff-cover.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   deploy:
-    if: github.repository_owner == 'riseproject-dev' && needs.resolve.outputs.environment != ''
-    name: "deploy to ${{ needs.resolve.outputs.environment }}"
-    needs: [test, resolve]
+    if: github.repository_owner == 'riseproject-dev' && needs.setup.outputs.environment != ''
+    name: "deploy to ${{ needs.setup.outputs.environment }}"
+    needs: [test, setup]
     runs-on: ubuntu-latest
-    environment: ${{ needs.resolve.outputs.environment }}
+    environment: ${{ needs.setup.outputs.environment }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false
@@ -80,8 +124,8 @@ jobs:
           file: container/Dockerfile
           target: ghfe
           tags: |
-            ${{ needs.resolve.outputs.environment == 'main'    && format('{0}/{1}:ghfe-latest', env.REGISTRY, env.IMAGE) || '' }}
-            ${{ needs.resolve.outputs.environment == 'staging' && format('{0}/{1}:ghfe-staging', env.REGISTRY, env.IMAGE) || '' }}
+            ${{ needs.setup.outputs.environment == 'main'    && format('{0}/{1}:ghfe-latest', env.REGISTRY, env.IMAGE) || '' }}
+            ${{ needs.setup.outputs.environment == 'staging' && format('{0}/{1}:ghfe-staging', env.REGISTRY, env.IMAGE) || '' }}
           cache-from: |
             type=gha,scope=ghfe-main
             ${{ format('type=gha,scope=type=gha,scope=ghfe-{0}', env.GITHUB_REF_NAME_SLUG) }}
@@ -97,8 +141,8 @@ jobs:
           file: container/Dockerfile
           target: scheduler
           tags: |
-            ${{ needs.resolve.outputs.environment == 'main'    && format('{0}/{1}:scheduler-latest', env.REGISTRY, env.IMAGE) || '' }}
-            ${{ needs.resolve.outputs.environment == 'staging' && format('{0}/{1}:scheduler-staging', env.REGISTRY, env.IMAGE) || '' }}
+            ${{ needs.setup.outputs.environment == 'main'    && format('{0}/{1}:scheduler-latest', env.REGISTRY, env.IMAGE) || '' }}
+            ${{ needs.setup.outputs.environment == 'staging' && format('{0}/{1}:scheduler-staging', env.REGISTRY, env.IMAGE) || '' }}
           cache-from: |
             type=gha,scope=scheduler-main
             ${{ format('type=gha,scope=type=gha,scope=scheduler-{0}', env.GITHUB_REF_NAME_SLUG) }}
@@ -107,7 +151,7 @@ jobs:
           push: true
 
       - name: Deploy to Scaleway
-        run: npm ci && npx serverless@3 deploy --stage=${{ needs.resolve.outputs.environment }}
+        run: npm ci && npx serverless@3 deploy --stage=${{ needs.setup.outputs.environment }}
         env:
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           GHAPP_WEBHOOK_SECRET: ${{ secrets.GHAPP_WEBHOOK_SECRET }}
@@ -117,10 +161,10 @@ jobs:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
 
       - name: Health check
-        run: python3 ./bin/check-health.py ${{ needs.resolve.outputs.environment == 'staging' && '--staging' || '' }}
+        run: python3 ./bin/check-health.py ${{ needs.setup.outputs.environment == 'staging' && '--staging' || '' }}
 
       - name: Trigger sample workflow
-        if: needs.resolve.outputs.environment == 'staging'
+        if: needs.setup.outputs.environment == 'staging'
         env:
           GH_TOKEN: ${{ secrets.RISCV_RUNNER_SAMPLE_ACCESS_TOKEN }}
           GH_REPO: riseproject-dev/riscv-runner-sample

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ package/
 *.py[cod]
 *$py.class
 *.so
+
+.coverage
+coverage.xml
+.pytest_cache/

--- a/container/scheduler.py
+++ b/container/scheduler.py
@@ -6,7 +6,8 @@ import random
 import string
 import threading
 import traceback
-from collections import defaultdict
+from collections.abc import Callable, Iterable
+from typing import Any
 
 import db
 from db import DuplicateRunnerNameException
@@ -92,124 +93,104 @@ def sync_jobs_state():
             db.mark_job_running(job_id, gh_job.get("runner_name"))
 
 
-def sync_workers_state():
+def _gh_runner_key_for_worker(worker):
+    """Return (installation_id, entity_type, entity_id, gh_runner_target).
+
+    For organizations: gh_runner_target = entity_name.
+    For users:         gh_runner_target = repo_full_name.
     """
-    Reconcile worker state across Kubernetes, GitHub, and the workers table.
+    entity_type = EntityType(worker["entity_type"])
+    target = worker["entity_name"] if entity_type == EntityType.ORGANIZATION else worker["repo_full_name"]
+    return (int(worker["installation_id"]), entity_type, int(worker["entity_id"]), target)
 
-    Runs under `db.hold_connection` + `LOCK TABLE workers IN EXCLUSIVE MODE` so
-    only one scheduler at a time executes these phases (even across replicas).
 
-    Phases:
-      1. Orphan sweep — workers in `pending`/`running` with no matching k8s pod
-         are marked completed.
-      2. Pod phase sync — k8s Running/Succeeded/Failed phases propagate to the
-         workers table (setting running_at / completed_at / failure_info).
-      3. Health checks — for pending/running workers grouped by GitHub runner
-         scope: if a Running pod older than RUNNER_REGISTRATION_TIMEOUT_SECONDS
-         is still missing from GH, or a Pending pod is older than
-         POD_PENDING_TIMEOUT_SECONDS, kill the pod (activeDeadlineSeconds=1)
-         so it transitions to Failed; the worker is marked failed with
-         diagnostics. If GitHub refuses to delete the runner (e.g. 422 "busy"),
-         abort cleanup for that worker — it may genuinely be running a job.
-      4. GitHub-side cleanup — any runner matching RUNNER_NAME_PREFIX whose
-         worker row is terminal or missing gets deleted on GitHub.
-      5. Delete k8s pods in Succeeded/Failed phase after POD_DELETE_GRACE_SECONDS
-         have elapsed since container termination, so operators can still
-         `kubectl logs` them during the grace window.
-    """
-
-    # GitHub runners registered to a given (installation_id, entity_type, entity_id, target)
-    gh_runners_by_target: dict[tuple, dict] = {}
-
-    def _gh_runner_key_for_worker(worker):
-        """Return (installation_id, entity_type, gh_runner_target).
-
-        For organizations: gh_runner_target = entity_name.
-        For users:         gh_runner_target = repo_full_name.
-        """
-        entity_type = EntityType(worker["entity_type"])
-        target = worker["entity_name"] if entity_type == EntityType.ORGANIZATION else worker["repo_full_name"]
-        return (int(worker["installation_id"]), entity_type, int(worker["entity_id"]), target)
-
-    def _get_gh_runners(gh_runner_key, token):
-        if gh_runner_key not in gh_runners_by_target:
-            _, entity_type, _, target = gh_runner_key
-            try:
-                if entity_type == EntityType.ORGANIZATION:
-                    group_id = gh.ensure_runner_group(target, token, RUNNER_GROUP_NAME)
-                    raw = gh.list_runners_org_group(token, target, group_id)
-                else:
-                    raw = [r for r in gh.list_runners_repo(token, target)
-                           if r.get("name", "").startswith(RUNNER_NAME_PREFIX)]
-            except gh.GitHubAPIError as e:
-                logger.error("Failed to list GH runners for %s/%s: %s", entity_type, target, e)
-                gh_runners_by_target[gh_runner_key] = {}
-                return gh_runners_by_target[gh_runner_key]
-            gh_runners_by_target[gh_runner_key] = {r["name"]: r for r in raw}
-        return gh_runners_by_target[gh_runner_key]
-
-    def _delete_gh_runner(worker_name, token, entity_type, gh_runner_target, runner_id):
-        """Delete a GH runner by id. Logs on failure, swallows exceptions."""
+def _get_gh_runners(gh_runner_key, token, gh_runners_by_target):
+    if gh_runner_key not in gh_runners_by_target:
+        _, entity_type, _, target = gh_runner_key
         try:
             if entity_type == EntityType.ORGANIZATION:
-                gh.delete_runner_org(token, gh_runner_target, runner_id)
+                group_id = gh.ensure_runner_group(target, token, RUNNER_GROUP_NAME)
+                raw = gh.list_runners_org_group(token, target, group_id)
             else:
-                gh.delete_runner_repo(token, gh_runner_target, runner_id)
-            logger.info("Deleted GH runner name=%s id=%s from entity=%s", worker_name, runner_id, gh_runner_target)
-            return True
-        except Exception as e:
-            logger.error("Failed to delete GH runner name=%s id=%s from entity=%s: %s", worker_name, runner_id, gh_runner_target, e)
-            return False
-
-    def _fail_and_cleanup(worker, pod, token, entity_type, gh_runner_target, gh_runner: dict | None, reason: FailureReason):
-        """Mark a worker failed, kill its pod, and remove any stale GH registration.
-
-        If GitHub has a runner for this worker (gh_runner is not None), try to delete
-        it first. A non-2xx from GitHub (e.g. 422 "runner is busy") is our signal
-        that GH thinks a job is actually executing — abort cleanup so we don't kill
-        a worker that is doing useful work we missed signal for. Otherwise proceed:
-        collect diagnostics, mark the worker failed, and kill the pod so its slot
-        frees up. Phase 5's grace window later removes the Failed pod.
-        """
-        logger.warning("Health check failed for pod=%s reason=%s", worker["pod_name"], reason.value)
-        if gh_runner:
-            if not _delete_gh_runner(worker["pod_name"], token, entity_type, gh_runner_target, gh_runner["id"]):
-                logger.warning("Aborting cleanup for worker=%s: GitHub refused to delete the runner (may be running a job)",
-                               worker["pod_name"])
-                return
-        try:
-            failure_info = k8s.collect_pod_failure_info(pod, reason=reason)
-        except Exception as e:
-            logger.error("collect_pod_failure_info failed for %s: %s", worker["pod_name"], e)
-            failure_info = {"version": 2, "reason": reason.value, "collect_error": str(e)}
-        db.mark_worker_failed(worker["pod_name"],
-                              pod.spec.node_name or worker["k8s_node"],
-                              failure_info,
-                              datetime.datetime.now(datetime.timezone.utc))
-        try:
-            k8s.kill_pod(pod)
-        except Exception as e:
-            logger.error("kill_pod failed for %s: %s", pod.metadata.name, e)
-
-    def _age_seconds(ts):
-        """Seconds elapsed since ts (a datetime, possibly naive). Returns +inf if ts is None."""
-        if ts is None:
-            return float("inf")
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=datetime.timezone.utc)
-        return (datetime.datetime.now(datetime.timezone.utc) - ts).total_seconds()
+                raw = [r for r in gh.list_runners_repo(token, target)
+                       if r.get("name", "").startswith(RUNNER_NAME_PREFIX)]
+        except gh.GitHubAPIError as e:
+            logger.error("Failed to list GH runners for %s/%s: %s", entity_type, target, e)
+            gh_runners_by_target[gh_runner_key] = {}
+            return gh_runners_by_target[gh_runner_key]
+        gh_runners_by_target[gh_runner_key] = {r["name"]: r for r in raw}
+    return gh_runners_by_target[gh_runner_key]
 
 
-    pods_by_name = {p.metadata.name: p for p in k8s.list_pods()}
-    workers_by_name = {w["pod_name"]: w for w in db.get_workers_for_reconcile()}
+def _delete_gh_runner(worker_name, token, entity_type, gh_runner_target, runner_id):
+    """Delete a GH runner by id. Logs on failure, swallows exceptions."""
+    try:
+        if entity_type == EntityType.ORGANIZATION:
+            gh.delete_runner_org(token, gh_runner_target, runner_id)
+        else:
+            gh.delete_runner_repo(token, gh_runner_target, runner_id)
+        logger.info("Deleted GH runner name=%s id=%s from entity=%s", worker_name, runner_id, gh_runner_target)
+        return True
+    except Exception as e:
+        logger.error("Failed to delete GH runner name=%s id=%s from entity=%s: %s", worker_name, runner_id, gh_runner_target, e)
+        return False
 
-    # --- Phase 1: Mark workers without any corresponding pods as orphaned ---
+
+def _fail_and_cleanup(worker, pod, token, entity_type, gh_runner_target, gh_runner: dict | None, reason: FailureReason):
+    """Mark a worker failed, kill its pod, and remove any stale GH registration.
+
+    If GitHub has a runner for this worker (gh_runner is not None), try to delete
+    it first. A non-2xx from GitHub (e.g. 422 "runner is busy") is our signal
+    that GH thinks a job is actually executing — abort cleanup so we don't kill
+    a worker that is doing useful work we missed signal for. Otherwise proceed:
+    collect diagnostics, mark the worker failed, and kill the pod so its slot
+    frees up. Phase 5's grace window later removes the Failed pod.
+    """
+    logger.warning("Health check failed for pod=%s reason=%s", worker["pod_name"], reason.value)
+    if gh_runner:
+        if not _delete_gh_runner(worker["pod_name"], token, entity_type, gh_runner_target, gh_runner["id"]):
+            logger.warning("Aborting cleanup for worker=%s: GitHub refused to delete the runner (may be running a job)",
+                           worker["pod_name"])
+            return
+    try:
+        failure_info = k8s.collect_pod_failure_info(pod, reason=reason)
+    except Exception as e:
+        logger.error("collect_pod_failure_info failed for %s: %s", worker["pod_name"], e)
+        failure_info = {"version": 2, "reason": reason.value, "collect_error": str(e)}
+    db.mark_worker_failed(worker["pod_name"],
+                          pod.spec.node_name or worker["k8s_node"],
+                          failure_info,
+                          datetime.datetime.now(datetime.timezone.utc))
+    try:
+        k8s.kill_pod(pod)
+    except Exception as e:
+        logger.error("kill_pod failed for %s: %s", pod.metadata.name, e)
+
+
+def _age_seconds(ts):
+    """Seconds elapsed since ts (a datetime, possibly naive). Returns +inf if ts is None."""
+    if ts is None:
+        return float("inf")
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.timezone.utc)
+    return (datetime.datetime.now(datetime.timezone.utc) - ts).total_seconds()
+
+
+def _group_by(elements: Iterable, key: Callable[[Any], Any]):
+    # itertools.groupby requires sorted elements by key before grouping by key
+    return itertools.groupby(sorted(elements, key=key), key=key)
+
+
+def _sync_workers_state_phase_1_orphan_sweep(pods_by_name, workers_by_name):
+    """Phase 1 of sync_workers_state: mark workers without any corresponding pods as orphaned."""
     for pod_name, w in workers_by_name.items():
         if pod_name not in pods_by_name and w["status"] in ["pending", "running"]:
             # There are no pods for that worker
             db.mark_worker_orphaned(pod_name)
 
-    # --- Phase 2: Synchronize pods status with the database ---
+
+def _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name):
+    """Phase 2 of sync_workers_state: synchronize pod phases with worker status in the database."""
     for pod_name, pod in pods_by_name.items():
         if pod.status.phase == "Running" and pod_name in workers_by_name and workers_by_name[pod_name]["status"] in ["pending"]:
             db.mark_worker_running(pod_name, pod.spec.node_name, k8s.get_runner_running_at(pod))
@@ -229,15 +210,18 @@ def sync_workers_state():
                 f"Failed pod {pod_name} requires failure_info with int 'version' field"
             db.mark_worker_failed(pod_name, pod.spec.node_name, failure_info, k8s.get_pod_finished_at(pod))
 
-    ### Refresh the list of workers
-    workers_by_name = {w["pod_name"]: w for w in db.get_workers_for_reconcile()}
 
-    # --- Phase 3: Github runner health checks ---
+def _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target):
+    """Phase 3 of sync_workers_state: GitHub runner health checks.
+
+    For pending/running workers grouped by GitHub runner scope: if a Running pod older
+    than RUNNER_REGISTRATION_TIMEOUT_SECONDS is still missing from GH, or a Pending pod
+    is older than POD_PENDING_TIMEOUT_SECONDS, kill the pod and mark the worker failed.
+    Populates ``gh_runners_by_target`` as a side effect for Phase 4 to consume.
+    """
     # Sort before groupby so workers with the same scope are grouped together
     # (groupby only groups adjacent equal keys).
-    workers_by_gh_runner_key = itertools.groupby(sorted(
-        (w for w in workers_by_name.values() if w["status"] in ["pending", "running"]),
-        key=_gh_runner_key_for_worker), key=_gh_runner_key_for_worker)
+    workers_by_gh_runner_key = _group_by((w for w in workers_by_name.values() if w["status"] in ["pending", "running"]), key=_gh_runner_key_for_worker)
     for gh_runner_key, workers in workers_by_gh_runner_key:
         installation_id, entity_type, entity_id, gh_runner_target = gh_runner_key
         try:
@@ -249,7 +233,7 @@ def sync_workers_state():
         # Consume the groupby elements into a list that we can iterate multiple times
         workers = list(workers)
 
-        gh_runners = _get_gh_runners(gh_runner_key, token)
+        gh_runners = _get_gh_runners(gh_runner_key, token, gh_runners_by_target)
 
         logger.debug(f"Checking for workers={RUNNER_NAME_PREFIX}%s in runners={RUNNER_NAME_PREFIX}%s for target=%s entity_type=%s",
                     sorted([w["pod_name"].removeprefix(RUNNER_NAME_PREFIX) for w in workers]),
@@ -296,13 +280,16 @@ def sync_workers_state():
                                         reason=FailureReason.RUNNER_NEVER_REGISTERED)
                     continue
 
-            else:
-                logger.info("Worker worker=%s worker_status=%s skipped", w["pod_name"], w["status"])
+            else: # pragma: no cover
+                assert False, f"unexpected worker status {w['status']!r} for {w['pod_name']}: the groupby filter restricts to pending/running"
 
-    ### Refresh the list of workers
-    workers_by_name = {w["pod_name"]: w for w in db.get_workers_for_reconcile()}
 
-    # --- Phase 4: GH-side cleanup (delete orphan/completed/failed runners in GitHub) ---
+def _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target):
+    """Phase 4 of sync_workers_state: delete orphan/completed/failed runners on GitHub.
+
+    Any runner matching RUNNER_NAME_PREFIX whose worker row is terminal or missing
+    gets deleted on GitHub. Reads the cache populated by Phase 3.
+    """
     for gh_runner_key, gh_runners in gh_runners_by_target.items():
         installation_id, entity_type, _, gh_runner_target = gh_runner_key
         try:
@@ -322,7 +309,13 @@ def sync_workers_state():
                 _delete_gh_runner(name, token, entity_type, gh_runner_target, gh_runner["id"])
 
 
-    # --- Phase 5: Delete completed|failed pods only after the grace period. ---
+def _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name):
+    """Phase 5 of sync_workers_state: delete completed|failed pods after the grace period.
+
+    Pods in Succeeded/Failed phase are kept for POD_DELETE_GRACE_SECONDS so operators
+    can still inspect them via ``kubectl logs``; once the grace window elapses they
+    are deleted from the cluster.
+    """
     now = datetime.datetime.now(datetime.timezone.utc)
     for pod_name, pod in pods_by_name.items():
         if pod.status.phase not in ("Succeeded", "Failed"):
@@ -337,6 +330,42 @@ def sync_workers_state():
             k8s.delete_pod(pod)
         except Exception as e:
             logger.error("Failed to delete pod %s: %s", pod.metadata.name, e)
+
+
+def sync_workers_state():
+    """Reconcile worker state across Kubernetes, GitHub, and the workers table."""
+    pods_by_name = {p.metadata.name: p for p in k8s.list_pods()}
+
+    # GitHub runners registered to a given (installation_id, entity_type, entity_id, target).
+    # Phase 3 populates this lazily; Phase 4 reads from it.
+    gh_runners_by_target: dict[tuple, dict] = {}
+
+    workers_by_name = {w["pod_name"]: w for w in db.get_workers_for_reconcile()}
+    # 1. Orphan sweep — workers in `pending`/`running` with no matching k8s pod
+    #    are marked completed.
+    _sync_workers_state_phase_1_orphan_sweep(pods_by_name, workers_by_name)
+    # 2. Pod phase sync — k8s Running/Succeeded/Failed phases propagate to the
+    #    workers table (setting running_at / completed_at / failure_info).
+    _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name)
+
+    workers_by_name = {w["pod_name"]: w for w in db.get_workers_for_reconcile()} # refresh workers
+    # 3. Health checks — for pending/running workers grouped by GitHub runner
+    #    scope: if a Running pod older than RUNNER_REGISTRATION_TIMEOUT_SECONDS
+    #    is still missing from GH, or a Pending pod is older than
+    #    POD_PENDING_TIMEOUT_SECONDS, kill the pod (activeDeadlineSeconds=1)
+    #    so it transitions to Failed; the worker is marked failed with
+    #    diagnostics. If GitHub refuses to delete the runner (e.g. 422 "busy"),
+    #    abort cleanup for that worker — it may genuinely be running a job.
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
+
+    workers_by_name = {w["pod_name"]: w for w in db.get_workers_for_reconcile()} # refresh workers
+    # 4. GitHub-side cleanup — any runner matching RUNNER_NAME_PREFIX whose
+    #    worker row is terminal or missing gets deleted on GitHub.
+    _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target)
+    # 5. Delete k8s pods in Succeeded/Failed phase after POD_DELETE_GRACE_SECONDS
+    #    have elapsed since container termination, so operators can still
+    #    `kubectl logs` them during the grace window.
+    _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name)
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.coverage.run]
+source = ["container"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=term-missing --cov-report=xml"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,6 @@
 
 requests-mock==1.12.1
 pytest
+pytest-cov
 pytest-xdist
+diff-cover

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -20,6 +20,15 @@ from scheduler import (
     _parse_date_param,
     _build_link_header,
     _scheduler_iteration,
+    _age_seconds,
+    _delete_gh_runner,
+    _get_gh_runners,
+    _gh_runner_key_for_worker,
+    _sync_workers_state_phase_1_orphan_sweep,
+    _sync_workers_state_phase_2_pod_phase_sync,
+    _sync_workers_state_phase_3_health_checks,
+    _sync_workers_state_phase_4_gh_cleanup,
+    _sync_workers_state_phase_5_delete_terminal_pods,
 )
 
 
@@ -276,40 +285,123 @@ def _configure_db_mock(mock_db, workers=None):
     return conn, cur
 
 
+def _phase_state(mock_db, mock_list_pods):
+    """Build the (pods_by_name, workers_by_name, gh_runners_by_target) tuple that
+    sync_workers_state would pass to each phase. Use in tests that call a single
+    phase function directly so the orchestrator's setup is mirrored exactly.
+    """
+    pods = list(mock_list_pods.return_value or [])
+    pods_by_name = {p.metadata.name: p for p in pods}
+    workers_by_name = {w["pod_name"]: w for w in mock_db.get_workers_for_reconcile()}
+    return pods_by_name, workers_by_name, {}
+
+
+def _phase_state_with_gh_cache(mock_db, mock_list_pods, gh_runners):
+    """Same as _phase_state but pre-populates gh_runners_by_target with the given
+    runners under the scope of each pending/running worker (mirroring what Phase 3
+    would have built). Use in Phase 4 tests that bypass Phase 3.
+    """
+    pods_by_name, workers_by_name, cache = _phase_state(mock_db, mock_list_pods)
+    runner_dict = {r["name"]: r for r in gh_runners}
+    for w in workers_by_name.values():
+        if w["status"] not in ("pending", "running"):
+            continue
+        cache[_gh_runner_key_for_worker(w)] = runner_dict
+    return pods_by_name, workers_by_name, cache
+
+
+# sync_workers_state helpers — unit tests for module-private utilities used by the phases
+
+def test_age_seconds_returns_inf_for_none():
+    assert _age_seconds(None) == float("inf")
+
+
+def test_age_seconds_treats_naive_datetime_as_utc():
+    naive = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) \
+        - datetime.timedelta(seconds=42)
+    assert _age_seconds(naive) == pytest.approx(42, abs=1)
+
+
+@patch("scheduler.gh.list_runners_org_group")
+@patch("scheduler.gh.ensure_runner_group", return_value=42)
+def test_get_gh_runners_returns_empty_on_github_api_error(mock_group, mock_list_gh):
+    """A GitHubAPIError while listing runners must yield an empty cache entry,
+    not propagate up — Phase 3 depends on this to keep processing other scopes."""
+    from github import GitHubAPIError
+    mock_list_gh.side_effect = GitHubAPIError(503, "service unavailable")
+    cache = {}
+    key = (999, EntityType.ORGANIZATION, 1000, "test-org")
+
+    result = _get_gh_runners(key, "token-123", cache)
+
+    assert result == {}
+    assert cache[key] == {}
+
+
+@patch("scheduler.gh.list_runners_org_group")
+@patch("scheduler.gh.ensure_runner_group", return_value=42)
+def test_get_gh_runners_uses_cache_on_subsequent_calls(mock_group, mock_list_gh):
+    """When the same (installation, scope) key is queried twice, the second call
+    must return the cached dict without hitting the GitHub API again — this is what
+    lets Phase 4 reuse Phase 3's listing under the same orchestrator invocation."""
+    key = (999, EntityType.ORGANIZATION, 1000, "test-org")
+    cache = {key: {"runner-1": {"id": 7, "name": "runner-1", "status": "online"}}}
+
+    result = _get_gh_runners(key, "token-123", cache)
+
+    assert result is cache[key]
+    mock_list_gh.assert_not_called()
+    mock_group.assert_not_called()
+
+
+@patch("scheduler.gh.delete_runner_repo")
+def test_delete_gh_runner_user_branch_calls_repo_endpoint(mock_delete_repo):
+    """The USER branch dispatches to gh.delete_runner_repo — Phase 3/4's ORG-only
+    tests don't exercise this path."""
+    ok = _delete_gh_runner("rise-riscv-runner-staging-pod-1", "token-user",
+                            EntityType.USER, "someuser/myrepo", 77)
+
+    assert ok is True
+    mock_delete_repo.assert_called_once_with("token-user", "someuser/myrepo", 77)
+
+
 # Phase 1 — orphan sweep
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods", return_value=[])
-def test_reconcile_orphans_worker_with_no_pod(mock_list, mock_db):
+def test_phase_1_orphans_worker_with_no_pod(mock_list, mock_db):
     worker = make_worker(pod_name="pod-1", status="pending")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_1_orphan_sweep(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_orphaned.assert_called_once_with("pod-1")
 
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods", return_value=[])
-def test_reconcile_does_not_orphan_terminal_workers(mock_list, mock_db):
+def test_phase_1_does_not_orphan_terminal_workers(mock_list, mock_db):
     w1 = make_worker(pod_name="pod-completed", status="completed")
     w2 = make_worker(pod_name="pod-failed", status="failed")
     _configure_db_mock(mock_db, workers=[w1, w2])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_1_orphan_sweep(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_orphaned.assert_not_called()
 
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
-def test_reconcile_does_not_orphan_worker_with_matching_pod(mock_list, mock_db):
+def test_phase_1_does_not_orphan_worker_with_matching_pod(mock_list, mock_db):
     pod = make_running_pod("pod-1")
     mock_list.return_value = [pod]
     worker = make_worker(pod_name="pod-1", status="running")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_1_orphan_sweep(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_orphaned.assert_not_called()
 
@@ -318,14 +410,15 @@ def test_reconcile_does_not_orphan_worker_with_matching_pod(mock_list, mock_db):
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
-def test_reconcile_syncs_pending_to_running(mock_list, mock_db):
+def test_phase_2_syncs_pending_to_running(mock_list, mock_db):
     started_at = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
     pod = make_running_pod("pod-1", running_at=started_at)
     mock_list.return_value = [pod]
     worker = make_worker(pod_name="pod-1", status="pending")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_running.assert_called_once()
     args = mock_db.mark_worker_running.call_args[0]
@@ -335,14 +428,15 @@ def test_reconcile_syncs_pending_to_running(mock_list, mock_db):
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
-def test_reconcile_syncs_to_completed_on_succeeded(mock_list, mock_db):
+def test_phase_2_syncs_to_completed_on_succeeded(mock_list, mock_db):
     finished_at = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
     pod = make_terminal_pod("pod-1", phase="Succeeded", finished_at=finished_at)
     mock_list.return_value = [pod]
     worker = make_worker(pod_name="pod-1", status="running")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_completed.assert_called_once()
     args = mock_db.mark_worker_completed.call_args[0]
@@ -353,14 +447,15 @@ def test_reconcile_syncs_to_completed_on_succeeded(mock_list, mock_db):
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.k8s.collect_pod_failure_info", return_value={"version": 2, "reason": "pod_failed"})
-def test_reconcile_syncs_to_failed_on_pod_failed(mock_collect, mock_list, mock_db):
+def test_phase_2_syncs_to_failed_on_pod_failed(mock_collect, mock_list, mock_db):
     finished_at = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
     pod = make_terminal_pod("pod-1", phase="Failed", finished_at=finished_at)
     mock_list.return_value = [pod]
     worker = make_worker(pod_name="pod-1", status="running")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_failed.assert_called_once()
     args = mock_db.mark_worker_failed.call_args[0]
@@ -370,16 +465,38 @@ def test_reconcile_syncs_to_failed_on_pod_failed(mock_collect, mock_list, mock_d
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
-def test_reconcile_skips_sync_when_worker_already_terminal(mock_list, mock_db):
+def test_phase_2_skips_sync_when_worker_already_terminal(mock_list, mock_db):
     pod = make_running_pod("pod-1")
     mock_list.return_value = [pod]
     worker = make_worker(pod_name="pod-1", status="completed")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
 
-    sync_workers_state()
+    _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name)
 
     mock_db.mark_worker_running.assert_not_called()
     mock_db.mark_worker_failed.assert_not_called()
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.collect_pod_failure_info", side_effect=RuntimeError("boom"))
+def test_phase_2_falls_back_when_collect_pod_failure_info_raises(mock_collect, mock_list, mock_db):
+    """k8s.collect_pod_failure_info exception must not abort the sync — the worker is
+    still marked failed with a fallback failure_info dict carrying the collect_error."""
+    finished_at = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    pod = make_terminal_pod("pod-1", phase="Failed", finished_at=finished_at)
+    mock_list.return_value = [pod]
+    worker = make_worker(pod_name="pod-1", status="running")
+    _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, _ = _phase_state(mock_db, mock_list)
+
+    _sync_workers_state_phase_2_pod_phase_sync(pods_by_name, workers_by_name)
+
+    mock_db.mark_worker_failed.assert_called_once()
+    failure_info = mock_db.mark_worker_failed.call_args[0][2]
+    assert failure_info["reason"] == "pod_failed"
+    assert failure_info["collect_error"] == "boom"
 
 
 # Phase 3 — stuck-runner health checks
@@ -391,7 +508,7 @@ def test_reconcile_skips_sync_when_worker_already_terminal(mock_list, mock_db):
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_fails_runner_that_never_registered_past_timeout(
+def test_phase_3_fails_runner_that_never_registered_past_timeout(
         mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         seconds=RUNNER_REGISTRATION_TIMEOUT_SECONDS + 30)
@@ -400,8 +517,9 @@ def test_reconcile_fails_runner_that_never_registered_past_timeout(
     worker = make_worker(pod_name="rise-riscv-runner-staging-pod-1",
                          status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_called_once()
     args = mock_db.mark_worker_failed.call_args[0]
@@ -416,7 +534,7 @@ def test_reconcile_fails_runner_that_never_registered_past_timeout(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_skips_runner_that_already_ran_a_job(
+def test_phase_3_skips_runner_that_already_ran_a_job(
         mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
     """A runner missing from GH but with a matching jobs.k8s_pod row has already
     run its job and self-unregistered — do not flag as runner_never_registered."""
@@ -428,8 +546,9 @@ def test_reconcile_skips_runner_that_already_ran_a_job(
     worker = make_worker(pod_name=name, status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
     mock_db.job_exists_for_pod.return_value = True
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.job_exists_for_pod.assert_called_with(name)
     mock_db.mark_worker_failed.assert_not_called()
@@ -442,7 +561,7 @@ def test_reconcile_skips_runner_that_already_ran_a_job(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_keeps_runner_within_registration_timeout(
+def test_phase_3_keeps_runner_within_registration_timeout(
         mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
     recent = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=10)
     pod = make_running_pod("rise-riscv-runner-staging-pod-1")
@@ -450,8 +569,9 @@ def test_reconcile_keeps_runner_within_registration_timeout(
     worker = make_worker(pod_name="rise-riscv-runner-staging-pod-1",
                          status="running", running_at=recent)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_not_called()
     mock_kill.assert_not_called()
@@ -463,7 +583,7 @@ def test_reconcile_keeps_runner_within_registration_timeout(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group")
-def test_reconcile_keeps_registered_runner(
+def test_phase_3_keeps_registered_runner(
         mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
     name = "rise-riscv-runner-staging-pod-1"
@@ -472,8 +592,9 @@ def test_reconcile_keeps_registered_runner(
     mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online"}]
     worker = make_worker(pod_name=name, status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_not_called()
     mock_kill.assert_not_called()
@@ -486,7 +607,7 @@ def test_reconcile_keeps_registered_runner(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group")
-def test_reconcile_fails_offline_runner_past_timeout(
+def test_phase_3_fails_offline_runner_past_timeout(
         mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
     """A runner registered with GH but reported as `offline` past the registration
     timeout must be treated like an unregistered runner and marked failed."""
@@ -498,8 +619,9 @@ def test_reconcile_fails_offline_runner_past_timeout(
     mock_list_gh.return_value = [{"id": 11, "name": name, "status": "offline"}]
     worker = make_worker(pod_name=name, status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_called_once()
     args = mock_db.mark_worker_failed.call_args[0]
@@ -514,7 +636,7 @@ def test_reconcile_fails_offline_runner_past_timeout(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group")
-def test_reconcile_keeps_offline_runner_within_timeout(
+def test_phase_3_keeps_offline_runner_within_timeout(
         mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
     """An offline runner within the registration timeout window must be left alone —
     it may still come online before the deadline."""
@@ -525,8 +647,9 @@ def test_reconcile_keeps_offline_runner_within_timeout(
     mock_list_gh.return_value = [{"id": 11, "name": name, "status": "offline"}]
     worker = make_worker(pod_name=name, status="running", running_at=recent)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_not_called()
     mock_kill.assert_not_called()
@@ -539,7 +662,7 @@ def test_reconcile_keeps_offline_runner_within_timeout(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_fails_stuck_pending_pod_past_timeout(
+def test_phase_3_fails_stuck_pending_pod_past_timeout(
         mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         seconds=POD_PENDING_TIMEOUT_SECONDS + 60)
@@ -548,8 +671,9 @@ def test_reconcile_fails_stuck_pending_pod_past_timeout(
     mock_list_pods.return_value = [pod]
     worker = make_worker(pod_name="rise-riscv-runner-staging-pod-1", status="pending")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_called_once()
     args = mock_db.mark_worker_failed.call_args[0]
@@ -563,15 +687,16 @@ def test_reconcile_fails_stuck_pending_pod_past_timeout(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_keeps_pending_pod_within_timeout(
+def test_phase_3_keeps_pending_pod_within_timeout(
         mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
     pod = make_pod("rise-riscv-runner-staging-pod-1", phase="Pending")
     pod.spec.node_name = None
     mock_list_pods.return_value = [pod]
     worker = make_worker(pod_name="rise-riscv-runner-staging-pod-1", status="pending")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_not_called()
     mock_kill.assert_not_called()
@@ -584,7 +709,7 @@ def test_reconcile_keeps_pending_pod_within_timeout(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_fail_and_cleanup_is_best_effort_on_kill_failure(
+def test_phase_3_fail_and_cleanup_is_best_effort_on_kill_failure(
         mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
     """kill_pod failure must not prevent the mark_worker_failed call."""
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
@@ -594,8 +719,9 @@ def test_reconcile_fail_and_cleanup_is_best_effort_on_kill_failure(
     worker = make_worker(pod_name="rise-riscv-runner-staging-pod-1",
                          status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_called_once()
     mock_kill.assert_called_once_with(pod)
@@ -609,7 +735,7 @@ def test_reconcile_fail_and_cleanup_is_best_effort_on_kill_failure(
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group")
 @patch("scheduler.gh.delete_runner_org", side_effect=Exception("422 runner is busy"))
-def test_reconcile_aborts_cleanup_when_github_refuses_delete(
+def test_phase_3_aborts_cleanup_when_github_refuses_delete(
         mock_delete, mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill,
         mock_list_pods, mock_db):
     """If GitHub refuses to delete the runner (e.g. 422 "runner is busy") we must
@@ -625,8 +751,9 @@ def test_reconcile_aborts_cleanup_when_github_refuses_delete(
     mock_list_gh.return_value = [{"id": 77, "name": name}]
     worker = make_worker(pod_name=name, status="pending")
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     # We attempted the delete.
     mock_delete.assert_called_once_with("token-123", "test-org", 77)
@@ -643,7 +770,7 @@ def test_reconcile_aborts_cleanup_when_github_refuses_delete(
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
 @patch("scheduler.gh.ensure_runner_group", return_value=42)
 @patch("scheduler.gh.list_runners_org_group", return_value=[])
-def test_reconcile_fail_and_cleanup_is_best_effort_on_collect_failure(
+def test_phase_3_fail_and_cleanup_is_best_effort_on_collect_failure(
         mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
     """collect_pod_failure_info exception -> mark_worker_failed still called with fallback."""
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
@@ -653,8 +780,9 @@ def test_reconcile_fail_and_cleanup_is_best_effort_on_collect_failure(
     worker = make_worker(pod_name="rise-riscv-runner-staging-pod-1",
                          status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
 
     mock_db.mark_worker_failed.assert_called_once()
     failure_info = mock_db.mark_worker_failed.call_args[0][2]
@@ -662,34 +790,62 @@ def test_reconcile_fail_and_cleanup_is_best_effort_on_collect_failure(
     assert "collect_error" in failure_info
 
 
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.kill_pod")
+@patch("scheduler.gh.list_runners_org_group")
+def test_phase_3_skips_scope_when_authenticate_fails(
+        mock_list_gh, mock_kill, mock_list_pods, mock_db):
+    """A GitHubAPIError from authenticate_app must skip the entire scope without
+    killing pods or marking workers failed. We override the autouse default."""
+    from github import GitHubAPIError
+    name = "rise-riscv-runner-staging-pod-1"
+    pod = make_running_pod(name)
+    mock_list_pods.return_value = [pod]
+    worker = make_worker(pod_name=name, status="running",
+                         running_at=datetime.datetime.now(datetime.timezone.utc))
+    _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
+
+    with patch("scheduler.gh.authenticate_app",
+               side_effect=GitHubAPIError(500, "internal server error")):
+        _sync_workers_state_phase_3_health_checks(
+            pods_by_name, workers_by_name, gh_runners_by_target)
+
+    mock_db.mark_worker_failed.assert_not_called()
+    mock_kill.assert_not_called()
+    # We never reached the GH listing because auth failed first.
+    mock_list_gh.assert_not_called()
+
+
 # Phase 4 — GH-side cleanup
 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods", return_value=[])
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
-@patch("scheduler.gh.ensure_runner_group", return_value=42)
-@patch("scheduler.gh.list_runners_org_group")
 @patch("scheduler.gh.delete_runner_org")
-def test_reconcile_deletes_gh_runner_for_terminal_worker(
-        mock_delete, mock_list_gh, mock_group, mock_auth, mock_list_pods, mock_db):
+def test_phase_4_deletes_gh_runner_for_terminal_worker(
+        mock_delete, mock_auth, mock_list_pods, mock_db):
     """A terminal worker's GH runner must be deleted.
 
-    Phase 3 listing is per-scope and driven off pending/running workers; we need at
-    least one pending/running worker in the same scope so that the listing is fetched
-    and Phase 4 sees the terminal runner.
+    Phase 3 populates the gh_runners_by_target cache, keyed by the scope of any
+    pending/running worker; Phase 4 reads from that cache. We pre-populate it
+    via _phase_state_with_gh_cache so this test can exercise Phase 4 alone.
     """
     name = "rise-riscv-runner-staging-pod-1"
     active_pod = make_running_pod("rise-riscv-runner-staging-pod-active")
     mock_list_pods.return_value = [active_pod]
-    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online"},
-                                  {"id": 12, "name": "rise-riscv-runner-staging-pod-active", "status": "online"}]
+    gh_runners = [{"id": 11, "name": name, "status": "online"},
+                  {"id": 12, "name": "rise-riscv-runner-staging-pod-active", "status": "online"}]
     terminal_worker = make_worker(pod_name=name, status="completed")
     active_worker = make_worker(pod_name="rise-riscv-runner-staging-pod-active",
                                 status="running",
                                 running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[terminal_worker, active_worker])
+    _, workers_by_name, gh_runners_by_target = _phase_state_with_gh_cache(
+        mock_db, mock_list_pods, gh_runners)
 
-    sync_workers_state()
+    _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target)
 
     mock_delete.assert_any_call("token-123", "test-org", 11)
 
@@ -697,22 +853,22 @@ def test_reconcile_deletes_gh_runner_for_terminal_worker(
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
-@patch("scheduler.gh.ensure_runner_group", return_value=42)
-@patch("scheduler.gh.list_runners_org_group")
 @patch("scheduler.gh.delete_runner_org")
-def test_reconcile_deletes_gh_runner_with_no_worker_row(
-        mock_delete, mock_list_gh, mock_group, mock_auth, mock_list_pods, mock_db):
+def test_phase_4_deletes_gh_runner_with_no_worker_row(
+        mock_delete, mock_auth, mock_list_pods, mock_db):
     active_name = "rise-riscv-runner-staging-pod-active"
     orphan_name = "rise-riscv-runner-staging-pod-orphan"
     pod = make_running_pod(active_name)
     mock_list_pods.return_value = [pod]
-    mock_list_gh.return_value = [{"id": 11, "name": active_name, "status": "online"},
-                                  {"id": 99, "name": orphan_name, "status": "online"}]
+    gh_runners = [{"id": 11, "name": active_name, "status": "online"},
+                  {"id": 99, "name": orphan_name, "status": "online"}]
     active_worker = make_worker(pod_name=active_name, status="running",
                                 running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[active_worker])
+    _, workers_by_name, gh_runners_by_target = _phase_state_with_gh_cache(
+        mock_db, mock_list_pods, gh_runners)
 
-    sync_workers_state()
+    _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target)
 
     mock_delete.assert_any_call("token-123", "test-org", 99)
 
@@ -720,20 +876,20 @@ def test_reconcile_deletes_gh_runner_with_no_worker_row(
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
-@patch("scheduler.gh.ensure_runner_group", return_value=42)
-@patch("scheduler.gh.list_runners_org_group")
 @patch("scheduler.gh.delete_runner_org")
-def test_reconcile_keeps_gh_runner_with_active_worker(
-        mock_delete, mock_list_gh, mock_group, mock_auth, mock_list_pods, mock_db):
+def test_phase_4_keeps_gh_runner_with_active_worker(
+        mock_delete, mock_auth, mock_list_pods, mock_db):
     name = "rise-riscv-runner-staging-pod-1"
     pod = make_running_pod(name)
     mock_list_pods.return_value = [pod]
-    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online"}]
+    gh_runners = [{"id": 11, "name": name, "status": "online"}]
     worker = make_worker(pod_name=name, status="running",
                          running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[worker])
+    _, workers_by_name, gh_runners_by_target = _phase_state_with_gh_cache(
+        mock_db, mock_list_pods, gh_runners)
 
-    sync_workers_state()
+    _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target)
 
     mock_delete.assert_not_called()
 
@@ -741,27 +897,51 @@ def test_reconcile_keeps_gh_runner_with_active_worker(
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.gh.authenticate_app", return_value="token-123")
-@patch("scheduler.gh.ensure_runner_group", return_value=42)
-@patch("scheduler.gh.list_runners_org_group")
 @patch("scheduler.gh.delete_runner_org")
-def test_reconcile_skips_gh_runners_without_prefix(
-        mock_delete, mock_list_gh, mock_group, mock_auth, mock_list_pods, mock_db):
+def test_phase_4_skips_gh_runners_without_prefix(
+        mock_delete, mock_auth, mock_list_pods, mock_db):
     active_name = "rise-riscv-runner-staging-pod-active"
     pod = make_running_pod(active_name)
     mock_list_pods.return_value = [pod]
     # A foreign runner (no matching prefix) must never be deleted even if there is no
     # corresponding worker row.
-    mock_list_gh.return_value = [{"id": 11, "name": active_name, "status": "online"},
-                                  {"id": 99, "name": "some-other-teams-runner", "status": "online"}]
+    gh_runners = [{"id": 11, "name": active_name, "status": "online"},
+                  {"id": 99, "name": "some-other-teams-runner", "status": "online"}]
     active_worker = make_worker(pod_name=active_name, status="running",
                                 running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[active_worker])
+    _, workers_by_name, gh_runners_by_target = _phase_state_with_gh_cache(
+        mock_db, mock_list_pods, gh_runners)
 
-    sync_workers_state()
+    _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target)
 
     # Only called (if at all) for runners matching our prefix — never for the foreign name.
     for call_args in mock_delete.call_args_list:
         assert call_args[0][2] != 99, "foreign runner must not be deleted"
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.gh.delete_runner_org")
+def test_phase_4_skips_scope_when_authenticate_fails(
+        mock_delete, mock_list_pods, mock_db):
+    """If authenticate_app fails for a scope in Phase 4, no delete calls are issued
+    for that scope — we simply skip and continue."""
+    from github import GitHubAPIError
+    name = "rise-riscv-runner-staging-pod-1"
+    mock_list_pods.return_value = []
+    terminal_worker = make_worker(pod_name=name, status="completed")
+    _configure_db_mock(mock_db, workers=[terminal_worker])
+    # Pre-populate cache as if Phase 3 had built it.
+    key = _gh_runner_key_for_worker(terminal_worker)
+    workers_by_name = {w["pod_name"]: w for w in mock_db.get_workers_for_reconcile()}
+    gh_runners_by_target = {key: {name: {"id": 11, "name": name, "status": "online"}}}
+
+    with patch("scheduler.gh.authenticate_app",
+               side_effect=GitHubAPIError(500, "internal server error")):
+        _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target)
+
+    mock_delete.assert_not_called()
 
 
 # Phase 5 — grace period for terminal pods
@@ -769,14 +949,15 @@ def test_reconcile_skips_gh_runners_without_prefix(
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.k8s.delete_pod")
-def test_reconcile_deletes_terminal_pod_past_grace(mock_delete, mock_list_pods, mock_db):
+def test_phase_5_deletes_terminal_pod_past_grace(mock_delete, mock_list_pods, mock_db):
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         seconds=POD_DELETE_GRACE_SECONDS + 60)
     pod = make_terminal_pod("pod-1", phase="Succeeded", finished_at=old)
     mock_list_pods.return_value = [pod]
     _configure_db_mock(mock_db, workers=[])
+    pods_by_name, _, _ = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name)
 
     mock_delete.assert_called_once_with(pod)
 
@@ -784,12 +965,13 @@ def test_reconcile_deletes_terminal_pod_past_grace(mock_delete, mock_list_pods, 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.k8s.delete_pod")
-def test_reconcile_keeps_terminal_pod_within_grace(mock_delete, mock_list_pods, mock_db):
+def test_phase_5_keeps_terminal_pod_within_grace(mock_delete, mock_list_pods, mock_db):
     pod = make_terminal_pod("pod-1", phase="Succeeded")
     mock_list_pods.return_value = [pod]
     _configure_db_mock(mock_db, workers=[])
+    pods_by_name, _, _ = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name)
 
     mock_delete.assert_not_called()
 
@@ -797,14 +979,53 @@ def test_reconcile_keeps_terminal_pod_within_grace(mock_delete, mock_list_pods, 
 @patch("scheduler.db")
 @patch("scheduler.k8s.list_pods")
 @patch("scheduler.k8s.delete_pod")
-def test_reconcile_does_not_delete_running_pod(mock_delete, mock_list_pods, mock_db):
+def test_phase_5_does_not_delete_running_pod(mock_delete, mock_list_pods, mock_db):
     pod = make_running_pod("rise-riscv-runner-staging-pod-1")
     mock_list_pods.return_value = [pod]
     _configure_db_mock(mock_db, workers=[])
+    pods_by_name, _, _ = _phase_state(mock_db, mock_list_pods)
 
-    sync_workers_state()
+    _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name)
 
     mock_delete.assert_not_called()
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.delete_pod")
+def test_phase_5_treats_naive_finished_timestamp_as_utc(mock_delete, mock_list_pods, mock_db):
+    """A pod whose container.terminated.finished_at is a naive datetime past the grace
+    window must still be deleted — Phase 5 normalizes to UTC before comparing."""
+    naive_old = (datetime.datetime.now(datetime.timezone.utc)
+                 - datetime.timedelta(seconds=POD_DELETE_GRACE_SECONDS + 60)).replace(tzinfo=None)
+    pod = make_terminal_pod("pod-1", phase="Succeeded", finished_at=naive_old)
+    mock_list_pods.return_value = [pod]
+    _configure_db_mock(mock_db, workers=[])
+    pods_by_name, _, _ = _phase_state(mock_db, mock_list_pods)
+
+    _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name)
+
+    mock_delete.assert_called_once_with(pod)
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.delete_pod", side_effect=Exception("k8s api unreachable"))
+def test_phase_5_continues_when_delete_pod_fails(mock_delete, mock_list_pods, mock_db):
+    """k8s.delete_pod failure must be swallowed so the rest of the pod list is
+    still processed — the worker row is independent of pod deletion."""
+    old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=POD_DELETE_GRACE_SECONDS + 60)
+    pod1 = make_terminal_pod("pod-1", phase="Succeeded", finished_at=old)
+    pod2 = make_terminal_pod("pod-2", phase="Succeeded", finished_at=old)
+    mock_list_pods.return_value = [pod1, pod2]
+    _configure_db_mock(mock_db, workers=[])
+    pods_by_name, _, _ = _phase_state(mock_db, mock_list_pods)
+
+    # Should not raise even though every delete_pod call fails.
+    _sync_workers_state_phase_5_delete_terminal_pods(pods_by_name)
+
+    assert mock_delete.call_count == 2
 
 
 # Cross-cutting


### PR DESCRIPTION
The 5 phases of sync_workers_state are now module-level functions named
_sync_workers_state_phase_<N>_<purpose> so each can be tested in isolation
without driving the full orchestrator. The closure-captured helpers
(_get_gh_runners, _fail_and_cleanup, etc.) are also extracted so the
gh_runners_by_target cache is passed explicitly. The orchestrator keeps
the same call order, refresh points, and lock semantics as before.

Tests in tests/test_scheduler.py now call phase functions directly via
two new helpers (_phase_state, _phase_state_with_gh_cache) that mirror
the orchestrator's setup. Cross-cutting tests still exercise the full
orchestrator.

pytest-cov is added (report-only, no threshold). pyproject.toml configures
branch coverage over container/ and prints term-missing plus coverage.xml,
which CI uploads as a workflow artifact.