### PR TITLE
Refactor phase 3 health checks + cover new branches

### DIFF
--- a/container/constants.py
+++ b/container/constants.py
@@ -25,6 +25,7 @@ RUNNER_GROUP_NAME = f"RISE RISC-V Runners{'' if PROD else " (staging)"}"
 RUNNER_NAME_PREFIX = f"rise-riscv-runner{'' if PROD else '-staging'}-"
 
 RUNNER_REGISTRATION_TIMEOUT_SECONDS = 120           # pod Running but GH never sees runner
+RUNNER_PENDING_TIMEOUT_SECONDS      = 600        # pod Running but GH never picks up the runner
 POD_PENDING_TIMEOUT_SECONDS         = 600           # pod stuck Pending (no capacity, image pull, etc.)
 POD_DELETE_GRACE_SECONDS            = 6 * 60 * 60   # keep terminal pods around so logs remain inspectable
 

--- a/container/k8s.py
+++ b/container/k8s.py
@@ -14,8 +14,9 @@ logger = logging.getLogger(__name__)
 
 class FailureReason(str, Enum):
     POD_FAILED              = "pod_failed"
-    RUNNER_NEVER_REGISTERED = "runner_never_registered"
     POD_STUCK_PENDING       = "pod_stuck_pending"
+    RUNNER_NEVER_REGISTERED = "runner_never_registered"
+    RUNNER_IDLE             = "runner_idle"
 
 
 @functools.lru_cache(maxsize=1)

--- a/container/scheduler.py
+++ b/container/scheduler.py
@@ -244,44 +244,72 @@ def _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_
         for w in workers:
             assert w["pod_name"] in pods_by_name
             pod = pods_by_name[w["pod_name"]]
+            gh_runner = gh_runners.get(w["pod_name"])
 
-            if w["status"] == "pending":
+            worker_status = w["status"]
+            runner_status, runner_busy = (gh_runner["status"], gh_runner["busy"]) if gh_runner else (None, None)
+
+            # If the worker is still pending
+            if (worker_status) == ("pending"):
                 if _age_seconds(pod.metadata.creation_timestamp) < POD_PENDING_TIMEOUT_SECONDS:
                     logger.info("Worker worker=%s worker_status=%s is still pending", w["pod_name"], w["status"])
                     continue
                 logger.warning("Worker worker=%s worker_status=%s is still pending after more than %d seconds, marking as failed", w["pod_name"], w["status"], POD_PENDING_TIMEOUT_SECONDS)
-                _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runners.get(w["pod_name"]),
+                _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runner,
                                     reason=FailureReason.POD_STUCK_PENDING)
                 continue
 
-            elif w["status"] == "running":
-                gh_runner = gh_runners.get(w["pod_name"])
-                if gh_runner:
-                    if gh_runner["status"] != "offline":
-                        logger.debug("Worker worker=%s worker_status=%s is known github runner with runner_status=%s", w["pod_name"], w["status"], gh_runner["status"])
-                        continue
-                    if _age_seconds(w["running_at"]) < RUNNER_REGISTRATION_TIMEOUT_SECONDS:
-                        logger.info("Worker worker=%s worker_status=%s is known github runner and may still register", w["pod_name"], w["status"])
-                        continue
-                    logger.warning("Worker worker=%s worker_status=%s is known github runner and failed to register in %d seconds, marking as failed", w["pod_name"], w["status"], RUNNER_REGISTRATION_TIMEOUT_SECONDS)
-                    _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runner,
-                                        reason=FailureReason.RUNNER_NEVER_REGISTERED)
+            # If the worker is running but the runner is unknown, it may be that the runner has already self-unregistered after executing a job
+            elif (worker_status, runner_status) == ("running", None):
+                if db.job_exists_for_pod(w["pod_name"]):
+                    logger.debug("Worker worker=%s worker_status=%s runner has already run a job and self-unregistered, skipping", w["pod_name"], w["status"])
                     continue
+                if _age_seconds(w["running_at"]) < RUNNER_REGISTRATION_TIMEOUT_SECONDS:
+                    logger.info("Worker worker=%s worker_status=%s is not known github runner and may still register", w["pod_name"], w["status"])
+                    continue
+                logger.warning("Worker worker=%s worker_status=%s is not known github runner and failed to register in %d seconds, marking as failed", w["pod_name"], w["status"], RUNNER_REGISTRATION_TIMEOUT_SECONDS)
+                _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runner,
+                                    reason=FailureReason.RUNNER_NEVER_REGISTERED)
+                continue
 
-                else:
-                    if db.job_exists_for_pod(w["pod_name"]):
-                        logger.info("Worker worker=%s worker_status=%s runner has already run a job and self-unregistered, skipping", w["pod_name"], w["status"])
-                        continue
-                    if _age_seconds(w["running_at"]) < RUNNER_REGISTRATION_TIMEOUT_SECONDS:
-                        logger.info("Worker worker=%s worker_status=%s is not known github runner and may still register", w["pod_name"], w["status"])
-                        continue
-                    logger.warning("Worker worker=%s worker_status=%s is not known github runner and failed to register in %d seconds, marking as failed", w["pod_name"], w["status"], RUNNER_REGISTRATION_TIMEOUT_SECONDS)
-                    _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, None,
-                                        reason=FailureReason.RUNNER_NEVER_REGISTERED)
+            # If the worker is running but the runner isn't running yet
+            elif (worker_status, runner_status) == ("running", "offline"):
+                if _age_seconds(w["running_at"]) < RUNNER_REGISTRATION_TIMEOUT_SECONDS:
+                    logger.info("Worker worker=%s worker_status=%s is known github runner and may still register", w["pod_name"], w["status"])
                     continue
+                logger.warning("Worker worker=%s worker_status=%s is known github runner and failed to register in %d seconds, marking as failed", w["pod_name"], w["status"], RUNNER_REGISTRATION_TIMEOUT_SECONDS)
+                _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runner,
+                                    reason=FailureReason.RUNNER_NEVER_REGISTERED)
+
+            # If the worker and runner are running but the runner hasn't picked up a job yet
+            elif (worker_status, runner_status, runner_busy) == ("running", "online", False):
+                if _age_seconds(w["running_at"]) < RUNNER_PENDING_TIMEOUT_SECONDS:
+                    logger.info("Worker worker=%s worker_status=%s is known github runner and may still pick up a job", w["pod_name"], w["status"])
+                    continue
+                logger.warning("Worker worker=%s worker_status=%s is known github runner and failed to pick up a job in %d seconds, marking as failed", w["pod_name"], w["status"], RUNNER_PENDING_TIMEOUT_SECONDS)
+                _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runner,
+                                    reason=FailureReason.RUNNER_IDLE)
+                continue
+
+            # If the worker and runner are running and the runner has picked up a job
+            elif (worker_status, runner_status, runner_busy) == ("running", "online", True):
+                # Nothing to do, everything is working!
+                pass
+
+            # If the worker is running, but the status of the runner is unknown
+            elif (worker_status) == ("running"):
+                assert runner_status not in [None, "offline", "online"]
+                logger.info("Worker worker=%s worker_status=%s has unkown github status runner_status=%s", w["pod_name"], w["status"], runner_status)
+                if _age_seconds(w["running_at"]) < RUNNER_REGISTRATION_TIMEOUT_SECONDS:
+                    logger.info("Worker worker=%s worker_status=%s is known github runner and may still register, runner_status=%s", w["pod_name"], w["status"], )
+                    continue
+                logger.warning("Worker worker=%s worker_status=%s is known github runner and in unknown state for after %d seconds, marking as failed", w["pod_name"], w["status"], RUNNER_REGISTRATION_TIMEOUT_SECONDS)
+                _fail_and_cleanup(w, pod, token, entity_type, gh_runner_target, gh_runner,
+                                    reason=FailureReason.RUNNER_NEVER_REGISTERED)
+                continue
 
             else: # pragma: no cover
-                assert False, f"unexpected worker status {w['status']!r} for {w['pod_name']}: the groupby filter restricts to pending/running"
+                assert False, f"unexpected worker status (worker_status={w['status']!r}, runner_status={runner_status!r}, runner_busy={runner_busy!r}) for worker={w['pod_name']}"
 
 
 def _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ mock_constants.POSTGRES_MAXCONN = 10
 mock_constants.RUNNER_GROUP_NAME = "RISE RISC-V Runners"
 mock_constants.RUNNER_NAME_PREFIX = "rise-riscv-runner-staging-"
 mock_constants.RUNNER_REGISTRATION_TIMEOUT_SECONDS = 120
+mock_constants.RUNNER_PENDING_TIMEOUT_SECONDS = 600
 mock_constants.POD_PENDING_TIMEOUT_SECONDS = 600
 mock_constants.POD_DELETE_GRACE_SECONDS = 6 * 60 * 60
 mock_constants.K8S_KUBECONFIG = None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,6 +9,7 @@ from constants import (
     POD_DELETE_GRACE_SECONDS,
     POD_PENDING_TIMEOUT_SECONDS,
     RUNNER_NAME_PREFIX,
+    RUNNER_PENDING_TIMEOUT_SECONDS,
     RUNNER_REGISTRATION_TIMEOUT_SECONDS,
 )
 from k8s import FailureReason
@@ -345,7 +346,7 @@ def test_get_gh_runners_uses_cache_on_subsequent_calls(mock_group, mock_list_gh)
     must return the cached dict without hitting the GitHub API again — this is what
     lets Phase 4 reuse Phase 3's listing under the same orchestrator invocation."""
     key = (999, EntityType.ORGANIZATION, 1000, "test-org")
-    cache = {key: {"runner-1": {"id": 7, "name": "runner-1", "status": "online"}}}
+    cache = {key: {"runner-1": {"id": 7, "name": "runner-1", "status": "online", "busy": True}}}
 
     result = _get_gh_runners(key, "token-123", cache)
 
@@ -589,7 +590,7 @@ def test_phase_3_keeps_registered_runner(
     name = "rise-riscv-runner-staging-pod-1"
     pod = make_running_pod(name)
     mock_list_pods.return_value = [pod]
-    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online"}]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online", "busy": True}]
     worker = make_worker(pod_name=name, status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
     pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
@@ -616,7 +617,7 @@ def test_phase_3_fails_offline_runner_past_timeout(
     name = "rise-riscv-runner-staging-pod-1"
     pod = make_running_pod(name)
     mock_list_pods.return_value = [pod]
-    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "offline"}]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "offline", "busy": False}]
     worker = make_worker(pod_name=name, status="running", running_at=old)
     _configure_db_mock(mock_db, workers=[worker])
     pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
@@ -644,7 +645,7 @@ def test_phase_3_keeps_offline_runner_within_timeout(
     name = "rise-riscv-runner-staging-pod-1"
     pod = make_running_pod(name)
     mock_list_pods.return_value = [pod]
-    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "offline"}]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "offline", "busy": False}]
     worker = make_worker(pod_name=name, status="running", running_at=recent)
     _configure_db_mock(mock_db, workers=[worker])
     pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
@@ -653,6 +654,119 @@ def test_phase_3_keeps_offline_runner_within_timeout(
 
     mock_db.mark_worker_failed.assert_not_called()
     mock_kill.assert_not_called()
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.kill_pod")
+@patch("scheduler.gh.authenticate_app", return_value="token-123")
+@patch("scheduler.gh.ensure_runner_group", return_value=42)
+@patch("scheduler.gh.list_runners_org_group")
+def test_phase_3_keeps_idle_online_runner_within_pending_timeout(
+        mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
+    """An online runner that hasn't picked up a job yet must be left alone if it is
+    still within RUNNER_PENDING_TIMEOUT_SECONDS — GH may still hand it work."""
+    recent = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=10)
+    name = "rise-riscv-runner-staging-pod-1"
+    pod = make_running_pod(name)
+    mock_list_pods.return_value = [pod]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online", "busy": False}]
+    worker = make_worker(pod_name=name, status="running", running_at=recent)
+    _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
+
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
+
+    mock_db.mark_worker_failed.assert_not_called()
+    mock_kill.assert_not_called()
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.kill_pod")
+@patch("scheduler.k8s.collect_pod_failure_info", return_value={"version": 2, "reason": "runner_idle"})
+@patch("scheduler.gh.authenticate_app", return_value="token-123")
+@patch("scheduler.gh.ensure_runner_group", return_value=42)
+@patch("scheduler.gh.list_runners_org_group")
+def test_phase_3_fails_idle_online_runner_past_pending_timeout(
+        mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
+    """An online runner that has been idle (busy=False) past RUNNER_PENDING_TIMEOUT_SECONDS
+    must be marked failed with reason RUNNER_IDLE — GH never assigned it a job, so the
+    slot is occupied for nothing and we want it freed for a retry."""
+    old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=RUNNER_PENDING_TIMEOUT_SECONDS + 30)
+    name = "rise-riscv-runner-staging-pod-1"
+    pod = make_running_pod(name)
+    mock_list_pods.return_value = [pod]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "online", "busy": False}]
+    worker = make_worker(pod_name=name, status="running", running_at=old)
+    _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
+
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
+
+    mock_db.mark_worker_failed.assert_called_once()
+    args = mock_db.mark_worker_failed.call_args[0]
+    assert args[0] == name
+    assert args[2]["reason"] == FailureReason.RUNNER_IDLE.value
+    mock_kill.assert_called_once_with(pod)
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.kill_pod")
+@patch("scheduler.gh.authenticate_app", return_value="token-123")
+@patch("scheduler.gh.ensure_runner_group", return_value=42)
+@patch("scheduler.gh.list_runners_org_group")
+def test_phase_3_keeps_runner_with_unknown_status_within_timeout(
+        mock_list_gh, mock_group, mock_auth, mock_kill, mock_list_pods, mock_db):
+    """A runner reporting an unrecognised status (anything other than online/offline)
+    within the registration window must be left alone — GH may still settle into a
+    known state before the deadline."""
+    recent = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=10)
+    name = "rise-riscv-runner-staging-pod-1"
+    pod = make_running_pod(name)
+    mock_list_pods.return_value = [pod]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "starting", "busy": False}]
+    worker = make_worker(pod_name=name, status="running", running_at=recent)
+    _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
+
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
+
+    mock_db.mark_worker_failed.assert_not_called()
+    mock_kill.assert_not_called()
+
+
+@patch("scheduler.db")
+@patch("scheduler.k8s.list_pods")
+@patch("scheduler.k8s.kill_pod")
+@patch("scheduler.k8s.collect_pod_failure_info", return_value={"version": 2, "reason": "runner_never_registered"})
+@patch("scheduler.gh.authenticate_app", return_value="token-123")
+@patch("scheduler.gh.ensure_runner_group", return_value=42)
+@patch("scheduler.gh.list_runners_org_group")
+def test_phase_3_fails_runner_with_unknown_status_past_timeout(
+        mock_list_gh, mock_group, mock_auth, mock_collect, mock_kill, mock_list_pods, mock_db):
+    """A runner stuck in an unrecognised status past RUNNER_REGISTRATION_TIMEOUT_SECONDS
+    must be marked failed as RUNNER_NEVER_REGISTERED — we treat any non-online state past
+    the deadline as a failed registration."""
+    old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=RUNNER_REGISTRATION_TIMEOUT_SECONDS + 30)
+    name = "rise-riscv-runner-staging-pod-1"
+    pod = make_running_pod(name)
+    mock_list_pods.return_value = [pod]
+    mock_list_gh.return_value = [{"id": 11, "name": name, "status": "starting", "busy": False}]
+    worker = make_worker(pod_name=name, status="running", running_at=old)
+    _configure_db_mock(mock_db, workers=[worker])
+    pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
+
+    _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_runners_by_target)
+
+    mock_db.mark_worker_failed.assert_called_once()
+    args = mock_db.mark_worker_failed.call_args[0]
+    assert args[0] == name
+    assert args[2]["reason"] == "runner_never_registered"
+    mock_kill.assert_called_once_with(pod)
 
 
 @patch("scheduler.db")
@@ -748,7 +862,7 @@ def test_phase_3_aborts_cleanup_when_github_refuses_delete(
     pod.spec.node_name = None
     mock_list_pods.return_value = [pod]
     # GH has the runner listed (so gh_runner is not None in _fail_and_cleanup).
-    mock_list_gh.return_value = [{"id": 77, "name": name}]
+    mock_list_gh.return_value = [{"id": 77, "name": name, "status": "online", "busy": False}]
     worker = make_worker(pod_name=name, status="pending")
     _configure_db_mock(mock_db, workers=[worker])
     pods_by_name, workers_by_name, gh_runners_by_target = _phase_state(mock_db, mock_list_pods)
@@ -835,8 +949,8 @@ def test_phase_4_deletes_gh_runner_for_terminal_worker(
     name = "rise-riscv-runner-staging-pod-1"
     active_pod = make_running_pod("rise-riscv-runner-staging-pod-active")
     mock_list_pods.return_value = [active_pod]
-    gh_runners = [{"id": 11, "name": name, "status": "online"},
-                  {"id": 12, "name": "rise-riscv-runner-staging-pod-active", "status": "online"}]
+    gh_runners = [{"id": 11, "name": name, "status": "online", "busy": True},
+                  {"id": 12, "name": "rise-riscv-runner-staging-pod-active", "status": "online", "busy": True}]
     terminal_worker = make_worker(pod_name=name, status="completed")
     active_worker = make_worker(pod_name="rise-riscv-runner-staging-pod-active",
                                 status="running",
@@ -860,8 +974,8 @@ def test_phase_4_deletes_gh_runner_with_no_worker_row(
     orphan_name = "rise-riscv-runner-staging-pod-orphan"
     pod = make_running_pod(active_name)
     mock_list_pods.return_value = [pod]
-    gh_runners = [{"id": 11, "name": active_name, "status": "online"},
-                  {"id": 99, "name": orphan_name, "status": "online"}]
+    gh_runners = [{"id": 11, "name": active_name, "status": "online", "busy": True},
+                  {"id": 99, "name": orphan_name, "status": "online", "busy": True}]
     active_worker = make_worker(pod_name=active_name, status="running",
                                 running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[active_worker])
@@ -882,7 +996,7 @@ def test_phase_4_keeps_gh_runner_with_active_worker(
     name = "rise-riscv-runner-staging-pod-1"
     pod = make_running_pod(name)
     mock_list_pods.return_value = [pod]
-    gh_runners = [{"id": 11, "name": name, "status": "online"}]
+    gh_runners = [{"id": 11, "name": name, "status": "online", "busy": True}]
     worker = make_worker(pod_name=name, status="running",
                          running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[worker])
@@ -905,8 +1019,8 @@ def test_phase_4_skips_gh_runners_without_prefix(
     mock_list_pods.return_value = [pod]
     # A foreign runner (no matching prefix) must never be deleted even if there is no
     # corresponding worker row.
-    gh_runners = [{"id": 11, "name": active_name, "status": "online"},
-                  {"id": 99, "name": "some-other-teams-runner", "status": "online"}]
+    gh_runners = [{"id": 11, "name": active_name, "status": "online", "busy": True},
+                  {"id": 99, "name": "some-other-teams-runner", "status": "online", "busy": True}]
     active_worker = make_worker(pod_name=active_name, status="running",
                                 running_at=datetime.datetime.now(datetime.timezone.utc))
     _configure_db_mock(mock_db, workers=[active_worker])
@@ -935,7 +1049,7 @@ def test_phase_4_skips_scope_when_authenticate_fails(
     # Pre-populate cache as if Phase 3 had built it.
     key = _gh_runner_key_for_worker(terminal_worker)
     workers_by_name = {w["pod_name"]: w for w in mock_db.get_workers_for_reconcile()}
-    gh_runners_by_target = {key: {name: {"id": 11, "name": name, "status": "online"}}}
+    gh_runners_by_target = {key: {name: {"id": 11, "name": name, "status": "online", "busy": True}}}
 
     with patch("scheduler.gh.authenticate_app",
                side_effect=GitHubAPIError(500, "internal server error")):
@@ -1063,8 +1177,8 @@ def test_reconcile_uses_repo_listing_for_user(
     # Two runners returned: one of ours, one foreign. The call-side filter in
     # _get_gh_runners strips the foreign one because it doesn't start with RUNNER_NAME_PREFIX.
     mock_list_repo.return_value = [
-        {"id": 11, "name": name, "status": "online"},
-        {"id": 22, "name": "random-self-hosted", "status": "online"},
+        {"id": 11, "name": name, "status": "online", "busy": True},
+        {"id": 22, "name": "random-self-hosted", "status": "online", "busy": True},
     ]
     worker = make_worker(pod_name=name, status="running",
                          entity_type=EntityType.USER,


### PR DESCRIPTION
## Summary
- Split sync_workers_state phase 3 into explicit (worker_status, runner_status, runner_busy) cases
- Introduce `RUNNER_IDLE` failure reason and `RUNNER_PENDING_TIMEOUT_SECONDS` for online-but-idle runners
- Add tests for the new idle-timeout branches (within and past timeout) and unrecognised GitHub runner statuses

## Test plan
- [ ] CI runs `pytest` on the refactored phase 3 logic
- [ ] diff-cover reports ≥80% coverage on the changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)