### PR TITLE
Add installation event logging and trace endpoints for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,105 @@ Phase 4 of `sync_workers_state` cleans up GitHub-registered runners once per cyc
 - Runners registered in GitHub with no matching worker row (orphans from a previous scheduler, crashed provisioning, etc.) are deleted.
 - For org-scoped runners the listing is scoped to the `RISE RISC-V Runners` runner group; for repo-scoped (personal accounts) runners are filtered by the `rise-riscv-runner{-staging}-` name prefix.
 
+### Installation event log
+
+When `gh.authenticate_app()` returns 404 in the scheduler, the matching job
+is marked `failed` with `installation not found` — but the *cause* of the
+404 is invisible. The user may have uninstalled the app, suspended it,
+removed our access to a specific repo, renamed their org/user account, or
+installed the wrong app variant on the wrong account type. Without
+captured history, we can't tell users why their jobs stopped getting
+picked up.
+
+`installation_events` is an append-only table that records, in
+chronological order:
+
+- Every webhook delivery the app receives (`installation`,
+  `installation_repositories`, `installation_target`, `workflow_job`,
+  `ping`, plus a row for any unhandled `X-GitHub-Event` we don't model).
+- Every scheduler `gh.authenticate_app()` failure (`auth_attempt.404`,
+  `auth_attempt.other_error`).
+
+Each row carries the full payload as `JSONB`, plus filter/index keys
+(`installation_id`, `app_id`, `entity_type`, `entity_id`, `entity_name`)
+and a free-form `outcome` string. The `WebhookOutcome` enum in
+`constants.py` is the canonical list of outcome values; the column itself
+is `TEXT` so new outcomes don't require schema migrations. `entity_id`
+is the GitHub `account.id`, which is stable across renames and reinstalls
+— uninstalling and reinstalling the app produces a new `installation_id`
+but keeps the same `entity_id`.
+
+The webhook handler writes the `jobs` side-effect (`add_job`,
+`mark_job_running`, `mark_job_completed`) and the `installation_events`
+row in **separate transactions**. If the log write fails the side effect
+has already committed; the handler returns 500 and GitHub redelivers.
+Re-deliveries converge: `add_job` uses `ON CONFLICT (job_id) DO NOTHING`,
+the worker-status updates are no-ops on a second run, and the log table
+has no UNIQUE constraint on payload so a duplicate log row is acceptable
+(the trace endpoints can dedupe by `delivery_id` from the JSONB payload
+when needed).
+
+The scheduler's `_gh_authenticate_app` wrapper logs only failures
+(`gh.authenticate_app` is `@ttl_cache`-decorated, so success is the hot
+path). `cachetools.func.ttl_cache` does not cache exceptions, so transient
+errors don't poison subsequent calls.
+
+#### State reconstruction
+
+The log is the source of truth for an entity's installation history. To
+answer *"what did installation X look like at time T?"* the trace tool
+fetches every event for that entity and folds the payloads in
+`received_at` order:
+
+| Event | State change |
+|---|---|
+| `installation.created` | initial repo set, `app_id`, `repository_selection`, `suspended=false` |
+| `installation_repositories.added` | `repos := repos ∪ payload.repositories_added` |
+| `installation_repositories.removed` | `repos := repos \ payload.repositories_removed` |
+| `installation.suspend` / `installation.unsuspend` | flip `suspended` |
+| `installation.deleted` | terminal — `installed=false`, `repos=∅` |
+| `installation_target.renamed` | `entity_name := payload.account.login` (the new name) |
+| `auth_attempt.404` | the scheduler's most recent failure, with the `app_id` it tried |
+
+Common diagnoses fall straight out of that fold:
+
+| Cause | Signal |
+|---|---|
+| User uninstalled between job submission and reconcile | `installation.deleted` row preceding the `auth_attempt.404` |
+| Admin suspended the installation | `installation.suspend` with no later `unsuspend` |
+| Admin removed access to a specific repo | `installation_repositories.removed` mentioning the failing repo |
+| Account renamed; cached `entity_name` is stale | `installation_target.renamed` |
+| JWT signed by the wrong app for this installation | `auth_attempt.404` row's `app_id` differs from `installation.created.app_id` |
+| `repository_selection=selected` and the repo isn't selected | `installation.created` shows `selected` and `installation_repositories.added` never adds the repo |
+
+#### Querying
+
+The `/trace/*` endpoints on `ghfe` return events as JSON. Authentication is
+a simple `Authorization: Bearer $TRACE_API_TOKEN` check (gates casual
+access only — not designed as a security boundary).
+
+```
+GET /trace/entity/<int:entity_id>             # all events for one entity
+GET /trace/installation/<int:installation_id> # resolves to entity_id, then same
+GET /trace/job/<int:job_id>                   # resolves job_id → entity_id via jobs.entity_id
+GET /trace/payload/<int:event_id>             # full JSONB payload for one row
+```
+
+The list endpoints intentionally **do not** return the `payload` field —
+payloads can be tens of KB each and most rows are reviewed at a glance.
+For `workflow_job.*` rows the response includes `job_id` and
+`repo_full_name` extracted in SQL so the timeline stays readable;
+`/trace/payload/<id>` is the way to get the full body for any individual
+row.
+
+`scripts/trace_installation.py` is a thin client over the trace endpoints
+with a chronological table renderer and rule-based diagnosis hints. It
+takes one of `--installation-id`, `--entity-id`, `--entity-name`, or
+`--job-id`. The `--entity-name` resolution shells out to `gh api
+/users/<login>` (falling back to `/orgs/<login>`) so it requires `gh auth
+login`. `PROD_URL` is hard-coded in the script; `TRACE_API_TOKEN` comes
+from the environment.
+
 ### Database schema
 
 Tables live in a `prod` or `staging` schema (same database, isolated by `SET search_path`).
@@ -242,6 +341,22 @@ CREATE TABLE workers (
     completed_at    TIMESTAMPTZ,          -- set when status transitions to completed|failed
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+CREATE TYPE entity_type_enum AS ENUM ('Organization', 'User');
+
+CREATE TABLE installation_events (
+    id                BIGSERIAL PRIMARY KEY,
+    source            TEXT NOT NULL,             -- 'webhook' or 'scheduler'
+    event             TEXT NOT NULL,             -- '{X-GitHub-Event}.{payload.action}' for webhooks, 'auth_attempt.{status}' for scheduler
+    outcome           TEXT NOT NULL,             -- WebhookOutcome enum value (open-set TEXT, no schema migration on add)
+    installation_id   BIGINT,
+    app_id            BIGINT,                    -- GHAPP_ORG_ID or GHAPP_PERSONAL_ID, populated from X-GitHub-Hook-Installation-Target-Id
+    entity_type       entity_type_enum,
+    entity_id         BIGINT,                    -- = installation.target_id = account.id (stable across renames)
+    entity_name       TEXT,                      -- account login (mirrors jobs.entity_name semantics)
+    payload           JSONB NOT NULL,            -- full webhook body, or synthesised dict for scheduler rows
+    received_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
 ```
 
 Status transitions are forward-only: `pending -> running -> (completed | failed)`. All UPDATE queries enforce this with explicit WHERE clauses. A `failed` worker does not count toward supply in `get_pool_demand`, so `demand_match` automatically re-provisions a runner for the same pending job on the next loop iteration.
@@ -281,6 +396,10 @@ Per-entity configuration is defined in `ENTITY_CONFIG` in `constants.py`, keyed 
 | `/health` | GET | Health check (returns `ok`) |
 | `/usage` | GET | Human-readable view of per-pool jobs and workers |
 | `/history` | GET | Job history sorted by status (pending, running, completed) then creation time |
+| `/trace/entity/<entity_id>` | GET | Installation event log for an entity (requires bearer token) |
+| `/trace/installation/<installation_id>` | GET | Resolves to `entity_id` then returns its event log |
+| `/trace/job/<job_id>` | GET | Resolves to `entity_id` via `jobs.entity_id` then returns its event log |
+| `/trace/payload/<event_id>` | GET | Full JSONB payload for one log row |
 
 **scheduler:**
 
@@ -299,6 +418,7 @@ Per-entity configuration is defined in `ENTITY_CONFIG` in `constants.py`, keyed 
 | `container/db.py` | PostgreSQL database operations |
 | `container/github.py` | GitHub API functions (auth, runner groups, JIT config, job status) |
 | `container/Dockerfile` | Docker image for the ghfe and scheduler containers |
+| `scripts/trace_installation.py` | CLI client for the `/trace/*` endpoints — chronological table + diagnosis hints |
 
 ### Infrastructure
 
@@ -359,6 +479,7 @@ The following secrets must be configured in the repository settings (Settings > 
 | `GHAPP_PERSONAL_PRIVATE_KEY` | GitHub App RSA private key for personal accounts (PEM format) |
 | `K8S_KUBECONFIG` | Kubeconfig for the Kubernetes cluster |
 | `POSTGRES_URL` | PostgreSQL connection string (e.g. `postgresql://user:pass@<host>:5432/db?sslmode=require`) |
+| `TRACE_API_TOKEN` | Bearer token gating `/trace/*` endpoints (and the `trace_installation.py` script) |
 | `RISCV_RUNNER_SAMPLE_ACCESS_TOKEN` | PAT for triggering sample workflow on staging deploy |
 
 ## Kubernetes cluster provisioning

--- a/container/constants.py
+++ b/container/constants.py
@@ -5,6 +5,21 @@ class EntityType(str, Enum):
     ORGANIZATION = "Organization"
     USER = "User"
 
+
+class WebhookOutcome(str, Enum):
+    """Stored verbatim in installation_events.outcome (TEXT column)."""
+    OK = "ok"
+    JOB_STORED = "job_stored"
+    JOB_ALREADY_EXISTS = "job_already_exists"
+    JOB_MARKED_RUNNING = "job_marked_running"
+    JOB_MARKED_COMPLETED = "job_marked_completed"
+    JOB_NOT_FOUND = "job_not_found"
+    IGNORED_ACTION = "ignored_action"
+    IGNORED_NO_LABEL = "ignored_no_label"
+    IGNORED_EVENT = "ignored_event"
+    AUTH_404 = "auth_404"
+    AUTH_OTHER_ERROR = "auth_other_error"
+
 PROD = os.environ["PROD"].lower() == "true"
 PROD_URL = os.environ["PROD_URL"]
 STAGING_URL = os.environ["STAGING_URL"]

--- a/container/constants.py
+++ b/container/constants.py
@@ -16,6 +16,7 @@ GHAPP_ORG_PRIVATE_KEY = os.environ["GHAPP_ORG_PRIVATE_KEY"]  # PEM-encoded priva
 GHAPP_PERSONAL_ID = 3131217  # https://github.com/apps/rise-risc-v-runners-personal
 GHAPP_PERSONAL_PRIVATE_KEY = os.environ["GHAPP_PERSONAL_PRIVATE_KEY"]  # PEM-encoded private key for the personal GitHub App
 GHAPP_WEBHOOK_SECRET = os.environ["GHAPP_WEBHOOK_SECRET"]  # Secret for validating GitHub webhook signatures
+TRACE_API_TOKEN = os.environ["TRACE_API_TOKEN"]  # Bearer token gating /trace/* endpoints
 
 POSTGRES_URL = os.environ["POSTGRES_URL"]  # postgresql://user:pass@host:5432/db?sslmode=require
 POSTGRES_SCHEMA = "prod" if PROD else "staging"

--- a/container/db.py
+++ b/container/db.py
@@ -275,10 +275,6 @@ def ensure_schema() -> None:
                 ON installation_events (installation_id, received_at DESC)
             """)
             cur.execute("""
-                CREATE INDEX IF NOT EXISTS idx_install_events_entity_name
-                ON installation_events (entity_name, received_at DESC)
-            """)
-            cur.execute("""
                 CREATE INDEX IF NOT EXISTS idx_install_events_entity
                 ON installation_events (entity_id, received_at DESC)
             """)

--- a/container/db.py
+++ b/container/db.py
@@ -177,6 +177,20 @@ def ensure_schema() -> None:
                     WHEN duplicate_object THEN null;
                 END $$
             """)
+            cur.execute("""
+                DO $$ BEGIN
+                    CREATE TYPE event_source_enum AS ENUM ('webhook', 'scheduler');
+                EXCEPTION
+                    WHEN duplicate_object THEN null;
+                END $$
+            """)
+            cur.execute("""
+                DO $$ BEGIN
+                    CREATE TYPE entity_type_enum AS ENUM ('Organization', 'User');
+                EXCEPTION
+                    WHEN duplicate_object THEN null;
+                END $$
+            """)
 
             # Jobs table
             cur.execute("""
@@ -241,6 +255,40 @@ def ensure_schema() -> None:
                 CREATE INDEX IF NOT EXISTS idx_workers_active
                 ON workers (entity_id, job_labels, k8s_pool)
                 WHERE status != 'completed'
+            """)
+
+            # Append-only event log for GitHub App install/uninstall/auth lifecycle.
+            # See plan: explains why an installation_id can disappear before a job
+            # is picked up. One row per webhook delivery + one per scheduler auth
+            # failure. Most context lives in `payload`; only filter/index keys
+            # are dedicated columns.
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS installation_events (
+                    id                BIGSERIAL PRIMARY KEY,
+                    source            event_source_enum NOT NULL,
+                    event             TEXT NOT NULL,
+                    outcome           TEXT NOT NULL,
+                    delivery_id       UUID,
+                    installation_id   BIGINT,
+                    app_id            BIGINT,
+                    entity_type       entity_type_enum,
+                    entity_id         BIGINT,
+                    account_login     TEXT,
+                    payload           JSONB NOT NULL,
+                    received_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_install_events_installation
+                ON installation_events (installation_id, received_at DESC)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_install_events_account
+                ON installation_events (account_login, received_at DESC)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_install_events_entity
+                ON installation_events (entity_id, received_at DESC)
             """)
 
         conn.autocommit = False
@@ -674,6 +722,123 @@ def get_workers_for_reconcile(terminal_lookback_seconds: int = 3600) -> list[psy
                        AND completed_at > now() - (%s || ' seconds')::interval)
             """, (int(terminal_lookback_seconds),))
             return cur.fetchall()
+
+
+# --- Installation event log ---
+
+def add_installation_event(
+    *,
+    source: str,
+    event: str,
+    outcome: str,
+    payload: dict,
+    delivery_id: str | None = None,
+    installation_id: int | None = None,
+    app_id: int | None = None,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    account_login: str | None = None,
+) -> int:
+    """Insert one installation_events row. Returns the new BIGSERIAL id.
+
+    `payload` is required (the column is JSONB NOT NULL); pass {} when there's
+    nothing to log. No ON CONFLICT — `delivery_id` isn't unique, so a redelivered
+    webhook produces a duplicate log row, which the trace tool dedupes at read
+    time. Caller is responsible for calling this in its own transaction (separate
+    from any side-effect writes); see the webhook handler.
+    """
+    assert payload is not None, "payload is required (pass {} for empty)"
+    with _get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO installation_events
+                    (source, event, outcome, delivery_id,
+                     installation_id, app_id, entity_type, entity_id,
+                     account_login, payload)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+            """, (source, event, outcome, delivery_id,
+                  installation_id, app_id, entity_type, entity_id,
+                  account_login, json.dumps(payload)))
+            return cur.fetchone()[0]
+
+
+def get_events_by_entity_id(entity_id: int) -> list[psycopg2.extras.RealDictRow]:
+    """Return all events for an entity, ordered by received_at.
+
+    For workflow_job.* rows, projects payload->workflow_job.id and
+    payload->repository.full_name as `job_id` / `repo_full_name` so the
+    timeline stays readable without a payload fetch. The full payload is
+    NOT projected — clients fetch it via /trace/payload/<id> when needed.
+    """
+    with _get_conn() as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("""
+                SELECT id, source, event, outcome, delivery_id,
+                       installation_id, app_id, entity_type, entity_id,
+                       account_login, received_at,
+                       CASE WHEN event LIKE 'workflow_job.%%'
+                            THEN payload->'workflow_job'->>'id' END AS job_id,
+                       CASE WHEN event LIKE 'workflow_job.%%'
+                            THEN payload->'repository'->>'full_name' END AS repo_full_name
+                FROM installation_events
+                WHERE entity_id = %s
+                ORDER BY received_at
+            """, (int(entity_id),))
+            return cur.fetchall()
+
+
+def get_payload_by_id(event_id: int) -> dict | None:
+    """Return only the JSONB payload for one installation_events row, or None."""
+    with _get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT payload FROM installation_events WHERE id = %s",
+                (int(event_id),),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+
+def get_entity_id_for_installation(installation_id: int) -> int | None:
+    """Resolve installation_id -> entity_id.
+
+    Looks first in installation_events for the most recent row with a non-NULL
+    entity_id (logged installations carry it). Falls back to jobs.entity_id if
+    no events exist for that installation_id yet (e.g. install pre-dates the
+    logging change).
+    """
+    with _get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT entity_id FROM installation_events
+                WHERE installation_id = %s AND entity_id IS NOT NULL
+                ORDER BY received_at DESC
+                LIMIT 1
+            """, (int(installation_id),))
+            row = cur.fetchone()
+            if row is not None:
+                return row[0]
+            cur.execute("""
+                SELECT entity_id FROM jobs
+                WHERE installation_id = %s
+                ORDER BY created_at DESC
+                LIMIT 1
+            """, (int(installation_id),))
+            row = cur.fetchone()
+            return row[0] if row else None
+
+
+def get_entity_id_for_job(job_id: int) -> int | None:
+    """Resolve job_id -> entity_id via the jobs table (one query)."""
+    with _get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT entity_id FROM jobs WHERE job_id = %s",
+                (int(job_id),),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
 
 
 # --- Pub/Sub ---

--- a/container/db.py
+++ b/container/db.py
@@ -272,7 +272,7 @@ def ensure_schema() -> None:
             """)
             cur.execute("""
                 CREATE INDEX IF NOT EXISTS idx_install_events_installation
-                ON installation_events (installation_id, received_at DESC)
+                ON installation_events (installation_id, entity_id)
             """)
             cur.execute("""
                 CREATE INDEX IF NOT EXISTS idx_install_events_entity

--- a/container/db.py
+++ b/container/db.py
@@ -179,13 +179,6 @@ def ensure_schema() -> None:
             """)
             cur.execute("""
                 DO $$ BEGIN
-                    CREATE TYPE event_source_enum AS ENUM ('webhook', 'scheduler');
-                EXCEPTION
-                    WHEN duplicate_object THEN null;
-                END $$
-            """)
-            cur.execute("""
-                DO $$ BEGIN
                     CREATE TYPE entity_type_enum AS ENUM ('Organization', 'User');
                 EXCEPTION
                     WHEN duplicate_object THEN null;
@@ -265,15 +258,14 @@ def ensure_schema() -> None:
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS installation_events (
                     id                BIGSERIAL PRIMARY KEY,
-                    source            event_source_enum NOT NULL,
+                    source            TEXT NOT NULL,
                     event             TEXT NOT NULL,
                     outcome           TEXT NOT NULL,
-                    delivery_id       UUID,
                     installation_id   BIGINT,
                     app_id            BIGINT,
                     entity_type       entity_type_enum,
                     entity_id         BIGINT,
-                    account_login     TEXT,
+                    entity_name       TEXT,
                     payload           JSONB NOT NULL,
                     received_at       TIMESTAMPTZ NOT NULL DEFAULT now()
                 )
@@ -283,8 +275,8 @@ def ensure_schema() -> None:
                 ON installation_events (installation_id, received_at DESC)
             """)
             cur.execute("""
-                CREATE INDEX IF NOT EXISTS idx_install_events_account
-                ON installation_events (account_login, received_at DESC)
+                CREATE INDEX IF NOT EXISTS idx_install_events_entity_name
+                ON installation_events (entity_name, received_at DESC)
             """)
             cur.execute("""
                 CREATE INDEX IF NOT EXISTS idx_install_events_entity
@@ -732,34 +724,31 @@ def add_installation_event(
     event: str,
     outcome: str,
     payload: dict,
-    delivery_id: str | None = None,
     installation_id: int | None = None,
     app_id: int | None = None,
     entity_type: str | None = None,
     entity_id: int | None = None,
-    account_login: str | None = None,
+    entity_name: str | None = None,
 ) -> int:
     """Insert one installation_events row. Returns the new BIGSERIAL id.
 
     `payload` is required (the column is JSONB NOT NULL); pass {} when there's
-    nothing to log. No ON CONFLICT — `delivery_id` isn't unique, so a redelivered
-    webhook produces a duplicate log row, which the trace tool dedupes at read
-    time. Caller is responsible for calling this in its own transaction (separate
-    from any side-effect writes); see the webhook handler.
+    nothing to log. Caller is responsible for calling this in its own
+    transaction (separate from any side-effect writes); see the webhook handler.
     """
     assert payload is not None, "payload is required (pass {} for empty)"
     with _get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute("""
                 INSERT INTO installation_events
-                    (source, event, outcome, delivery_id,
+                    (source, event, outcome,
                      installation_id, app_id, entity_type, entity_id,
-                     account_login, payload)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     entity_name, payload)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
-            """, (source, event, outcome, delivery_id,
+            """, (source, event, outcome,
                   installation_id, app_id, entity_type, entity_id,
-                  account_login, json.dumps(payload)))
+                  entity_name, json.dumps(payload)))
             return cur.fetchone()[0]
 
 
@@ -774,9 +763,9 @@ def get_events_by_entity_id(entity_id: int) -> list[psycopg2.extras.RealDictRow]
     with _get_conn() as conn:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute("""
-                SELECT id, source, event, outcome, delivery_id,
+                SELECT id, source, event, outcome,
                        installation_id, app_id, entity_type, entity_id,
-                       account_login, received_at,
+                       entity_name, received_at,
                        CASE WHEN event LIKE 'workflow_job.%%'
                             THEN payload->'workflow_job'->>'id' END AS job_id,
                        CASE WHEN event LIKE 'workflow_job.%%'

--- a/container/ghfe.py
+++ b/container/ghfe.py
@@ -102,20 +102,40 @@ def check_webhook_signature(headers, body):
     return event, body
 
 
-def check_webhook_event(body):
-    """Check if the event is a workflow_job with a handled action."""
+def _log_webhook_event(*, delivery_id, hook_target_id, event, payload,
+                       outcome, **overrides):
+    """Insert one installation_events row for a webhook delivery.
+
+    `event` and `payload` are caller-built. The helper extracts
+    installation/account fields from `payload` and falls back to
+    `hook_target_id` (X-GitHub-Hook-Installation-Target-Id, the delivering
+    app's id) when `payload.installation.app_id` is absent — needed for
+    workflow_job deliveries whose installation object is just a stub.
+    """
+    install = payload.get("installation") or {}
+    account = install.get("account") or payload.get("account") or {}
+    fields = dict(
+        installation_id=install.get("id"),
+        app_id=install.get("app_id") or hook_target_id,
+        entity_type=install.get("target_type") or account.get("type"),
+        entity_id=install.get("target_id") or account.get("id"),
+        account_login=account.get("login"),
+    )
+    fields.update(overrides)
     try:
-        payload = json.loads(body)
-    except json.JSONDecodeError:
-        logger.debug("Invalid JSON payload")
-        raise WebhookError(400, "Invalid JSON payload")
-
-    action = payload["action"]
-    if action not in ("queued", "in_progress", "completed"):
-        logger.debug("Ignoring action: %s", action)
-        raise WebhookError(200, f"Ignoring action: {action}")
-
-    return payload, action
+        db.add_installation_event(
+            source="webhook",
+            event=event,
+            outcome=outcome,
+            delivery_id=delivery_id,
+            payload=payload,
+            **fields,
+        )
+    except Exception:
+        # Bubble up so the caller's transaction view is honest, but make sure
+        # the response logs the original event/outcome for debugging.
+        logger.exception("Failed to record installation_events row event=%s outcome=%s", event, outcome)
+        raise
 
 
 def authorize_entity(payload):
@@ -272,15 +292,110 @@ def setup_personal():
     return _render_setup(expected=EntityType.USER)
 
 
+# --- /trace endpoints ---
+
+def _check_trace_auth():
+    """401 unless the Bearer token matches TRACE_API_TOKEN. Plain equality check."""
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {TRACE_API_TOKEN}":
+        raise WebhookError(401, "Unauthorized")
+
+
+def _trace_response(events):
+    return make_response(json.dumps({"events": events}, default=str), 200,
+                         {"Content-Type": "application/json"})
+
+
+@app.route("/trace/entity/<int:entity_id>", methods=["GET"])
+def trace_entity(entity_id):
+    _check_trace_auth()
+    events = db.get_events_by_entity_id(entity_id)
+    return _trace_response(events)
+
+
+@app.route("/trace/installation/<int:installation_id>", methods=["GET"])
+def trace_installation(installation_id):
+    _check_trace_auth()
+    entity_id = db.get_entity_id_for_installation(installation_id)
+    if entity_id is None:
+        return _trace_response([])
+    events = db.get_events_by_entity_id(entity_id)
+    return _trace_response(events)
+
+
+@app.route("/trace/job/<int:job_id>", methods=["GET"])
+def trace_job(job_id):
+    _check_trace_auth()
+    entity_id = db.get_entity_id_for_job(job_id)
+    if entity_id is None:
+        return _trace_response([])
+    events = db.get_events_by_entity_id(entity_id)
+    return _trace_response(events)
+
+
+@app.route("/trace/payload/<int:event_id>", methods=["GET"])
+def trace_payload(event_id):
+    _check_trace_auth()
+    payload = db.get_payload_by_id(event_id)
+    if payload is None:
+        return make_response(json.dumps({"error": "not found"}), 404,
+                             {"Content-Type": "application/json"})
+    return make_response(json.dumps({"payload": payload}, default=str), 200,
+                         {"Content-Type": "application/json"})
+
+
+def _parse_hook_target_id(headers) -> int | None:
+    raw = headers.get("X-GitHub-Hook-Installation-Target-Id")
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
 @app.route("/", methods=['POST'])
 def webhook():
     event, body = check_webhook_signature(request.headers, request.get_data(as_text=True))
 
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        logger.debug("Invalid JSON payload")
+        raise WebhookError(400, "Invalid JSON payload")
+
+    delivery_id = request.headers.get("X-GitHub-Delivery")
+    hook_target_id = _parse_hook_target_id(request.headers)
+    log_ctx = {"delivery_id": delivery_id, "hook_target_id": hook_target_id, "payload": payload}
+
     if event == "ping":
+        _log_webhook_event(event="ping", outcome="ok", **log_ctx)
         return f"pong"
 
+    elif event == "installation":
+        action = payload["action"]
+        _log_webhook_event(event=f"installation.{action}", outcome="ok", **log_ctx)
+        return f"installation.{action} logged"
+
+    elif event == "installation_repositories":
+        action = payload["action"]
+        _log_webhook_event(event=f"installation_repositories.{action}", outcome="ok", **log_ctx)
+        return f"installation_repositories.{action} logged"
+
+    elif event == "installation_target":
+        action = payload["action"]
+        _log_webhook_event(event=f"installation_target.{action}", outcome="ok", **log_ctx)
+        return f"installation_target.{action} logged"
+
     elif event == "workflow_job":
-        payload, action = check_webhook_event(body)
+        action = payload["action"]
+        wj_event = f"workflow_job.{action}"
+
+        # Ignore workflow_job actions we don't process (e.g. 'waiting').
+        if action not in ("queued", "in_progress", "completed"):
+            _log_webhook_event(event=wj_event, outcome="ignored_action", **log_ctx)
+            logger.debug("Ignoring action: %s", action)
+            return f"Ignoring action: {action}"
 
         owner_id, entity_type = authorize_entity(payload)
 
@@ -317,8 +432,14 @@ def webhook():
         # entity_id: owner_id (org) for organizations, repo_id for personal accounts
         entity_id = owner_id if entity_type == EntityType.ORGANIZATION else repo_id
 
-        # Make sure the required labels are present; Filters out unsupported jobs early
-        k8s_pool, k8s_image = match_labels_to_k8s(owner_id, repo_full_name, job_labels)
+        # Make sure the required labels are present; Filters out unsupported jobs early.
+        # If labels don't match, log + return — the WebhookError gets caught here so we
+        # can still record an `ignored_no_label` row before propagating the response.
+        try:
+            k8s_pool, k8s_image = match_labels_to_k8s(owner_id, repo_full_name, job_labels)
+        except WebhookError as e:
+            _log_webhook_event(event=wj_event, outcome="ignored_no_label", **log_ctx)
+            raise
 
         logger.info("Received %s workflow_job id=%s name=%s repo=%s labels=%s entity_type=%s",
                     action, job_id, payload["workflow_job"]["name"],
@@ -356,6 +477,9 @@ def webhook():
                 html_url=html_url,
             )
 
+            outcome = "job_stored" if stored else "job_already_exists"
+            _log_webhook_event(event=wj_event, outcome=outcome, **log_ctx)
+
             if stored:
                 return f"Job {job_id} stored."
             else:
@@ -363,6 +487,8 @@ def webhook():
 
         elif action == "in_progress":
             prev_status = db.mark_job_running(job_id, payload["workflow_job"].get("runner_name"))
+            outcome = "job_not_found" if prev_status is None else "job_marked_running"
+            _log_webhook_event(event=wj_event, outcome=outcome, **log_ctx)
             if prev_status is None:
                 logger.warning("Job %s not found on in_progress event", job_id)
                 return f"Job {job_id} not found."
@@ -371,15 +497,15 @@ def webhook():
 
         elif action == "completed":
             prev_status = db.mark_job_completed(job_id, payload["workflow_job"].get("runner_name"))
+            outcome = "job_not_found" if prev_status is None else "job_marked_completed"
+            _log_webhook_event(event=wj_event, outcome=outcome, **log_ctx)
             if prev_status is None:
                 logger.warning("Job %s not found on completed event", job_id)
                 return f"Job {job_id} not found."
             return f"Job {job_id} completed (was {prev_status})."
 
-        else:
-            return f"Ignoring {action} job"
-
     else:
+        _log_webhook_event(event=event, outcome="ignored_event", **log_ctx)
         return f"Ignoring {event} event"
 
 if __name__ == "__main__":

--- a/container/ghfe.py
+++ b/container/ghfe.py
@@ -6,6 +6,7 @@ import requests
 import time
 
 from flask import Flask, g, request, make_response
+from flask.json import dumps as json_dumps
 
 import db
 import github as gh
@@ -102,37 +103,27 @@ def check_webhook_signature(headers, body):
     return event, body
 
 
-def _log_webhook_event(*, hook_target_id, event, payload, outcome, **overrides):
+def _log_webhook_event(*, event, outcome, payload, app_id,
+                       installation_id=None, entity_type=None,
+                       entity_id=None, entity_name=None):
     """Insert one installation_events row for a webhook delivery.
 
-    `event` and `payload` are caller-built. The helper extracts
-    installation/account fields from `payload` and falls back to
-    `hook_target_id` (X-GitHub-Hook-Installation-Target-Id, the delivering
-    app's id) when `payload.installation.app_id` is absent — needed for
-    workflow_job deliveries whose installation object is just a stub.
-    `entity_name` mirrors `add_job` semantics: the owner login, taken from
-    `installation.account.login` (or top-level `account.login` for
-    installation_target.renamed) and falling back to
-    `repository.owner.login` for workflow_job payloads.
+    All fields are passed explicitly by the caller (each branch of
+    `webhook()` knows the exact payload shape for its event type and does
+    its own extraction). The helper just normalises `source="webhook"` and
+    handles the exception logging.
     """
-    install = payload.get("installation") or {}
-    account = install.get("account") or payload.get("account") or {}
-    repo_owner = (payload.get("repository") or {}).get("owner") or {}
-    fields = dict(
-        installation_id=install.get("id"),
-        app_id=install.get("app_id") or hook_target_id,
-        entity_type=install.get("target_type") or account.get("type") or repo_owner.get("type"),
-        entity_id=install.get("target_id") or account.get("id") or repo_owner.get("id"),
-        entity_name=account.get("login") or repo_owner.get("login"),
-    )
-    fields.update(overrides)
     try:
         db.add_installation_event(
             source="webhook",
             event=event,
             outcome=outcome,
             payload=payload,
-            **fields,
+            app_id=app_id,
+            installation_id=installation_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            entity_name=entity_name,
         )
     except Exception:
         # Bubble up so the caller's transaction view is honest, but make sure
@@ -304,16 +295,15 @@ def _check_trace_auth():
         raise WebhookError(401, "Unauthorized")
 
 
-def _trace_response(events):
-    return make_response(json.dumps({"events": events}, default=str), 200,
-                         {"Content-Type": "application/json"})
+def _json_response(data):
+    return make_response(json_dumps(data, default=str), 200, {"Content-Type": "application/json"})
 
 
 @app.route("/trace/entity/<int:entity_id>", methods=["GET"])
 def trace_entity(entity_id):
     _check_trace_auth()
     events = db.get_events_by_entity_id(entity_id)
-    return _trace_response(events)
+    return _json_response({"events": events})
 
 
 @app.route("/trace/installation/<int:installation_id>", methods=["GET"])
@@ -321,9 +311,9 @@ def trace_installation(installation_id):
     _check_trace_auth()
     entity_id = db.get_entity_id_for_installation(installation_id)
     if entity_id is None:
-        return _trace_response([])
+        raise WebhookError(404, "Entity not found")
     events = db.get_events_by_entity_id(entity_id)
-    return _trace_response(events)
+    return _json_response({"events": events})
 
 
 @app.route("/trace/job/<int:job_id>", methods=["GET"])
@@ -331,9 +321,9 @@ def trace_job(job_id):
     _check_trace_auth()
     entity_id = db.get_entity_id_for_job(job_id)
     if entity_id is None:
-        return _trace_response([])
+        raise WebhookError(404, "Entity not found")
     events = db.get_events_by_entity_id(entity_id)
-    return _trace_response(events)
+    return _json_response({"events": events})
 
 
 @app.route("/trace/payload/<int:event_id>", methods=["GET"])
@@ -341,20 +331,8 @@ def trace_payload(event_id):
     _check_trace_auth()
     payload = db.get_payload_by_id(event_id)
     if payload is None:
-        return make_response(json.dumps({"error": "not found"}), 404,
-                             {"Content-Type": "application/json"})
-    return make_response(json.dumps({"payload": payload}, default=str), 200,
-                         {"Content-Type": "application/json"})
-
-
-def _parse_hook_target_id(headers) -> int | None:
-    raw = headers.get("X-GitHub-Hook-Installation-Target-Id")
-    if not raw:
-        return None
-    try:
-        return int(raw)
-    except ValueError:
-        return None
+        raise WebhookError(404, "Payload not found")
+    return _json_response({"payload": payload})
 
 
 @app.route("/", methods=['POST'])
@@ -367,35 +345,87 @@ def webhook():
         logger.debug("Invalid JSON payload")
         raise WebhookError(400, "Invalid JSON payload")
 
-    hook_target_id = _parse_hook_target_id(request.headers)
-    log_ctx = {"hook_target_id": hook_target_id, "payload": payload}
+    if not "X-GitHub-Hook-Installation-Target-Id" in request.headers:
+        raise WebhookError(400, "Missing X-GitHub-Hook-Installation-Target-Id header")
+    try:
+        app_id = int(request.headers["X-GitHub-Hook-Installation-Target-Id"])
+    except ValueError:
+        raise WebhookError(400, "Invalid X-GitHub-Hook-Installation-Target-Id header")
 
     if event == "ping":
-        _log_webhook_event(event="ping", outcome="ok", **log_ctx)
+        _log_webhook_event(event="ping", outcome="ok", payload=payload, app_id=app_id)
         return f"pong"
 
     elif event == "installation":
         action = payload["action"]
-        _log_webhook_event(event=f"installation.{action}", outcome="ok", **log_ctx)
+        install = payload["installation"]
+        account = install.get("account") or {}
+        _log_webhook_event(
+            event=f"installation.{action}",
+            outcome="ok",
+            payload=payload,
+            app_id=app_id,
+            installation_id=install.get("id"),
+            entity_type=install.get("target_type") or account.get("type"),
+            entity_id=install.get("target_id") or account.get("id"),
+            entity_name=account.get("login"),
+        )
         return f"installation.{action} logged"
 
     elif event == "installation_repositories":
         action = payload["action"]
-        _log_webhook_event(event=f"installation_repositories.{action}", outcome="ok", **log_ctx)
+        install = payload["installation"]
+        account = install.get("account") or {}
+        _log_webhook_event(
+            event=f"installation_repositories.{action}",
+            outcome="ok",
+            payload=payload,
+            app_id=app_id,
+            installation_id=install.get("id"),
+            entity_type=install.get("target_type") or account.get("type"),
+            entity_id=install.get("target_id") or account.get("id"),
+            entity_name=account.get("login"),
+        )
         return f"installation_repositories.{action} logged"
 
     elif event == "installation_target":
         action = payload["action"]
-        _log_webhook_event(event=f"installation_target.{action}", outcome="ok", **log_ctx)
+        # `installation_target.renamed` carries the new account at top level;
+        # `installation.account` would be the pre-rename name, which is the wrong one.
+        account = payload.get("account") or {}
+        install = payload.get("installation") or {}
+        _log_webhook_event(
+            event=f"installation_target.{action}",
+            outcome="ok",
+            payload=payload,
+            app_id=app_id,
+            installation_id=install.get("id"),
+            entity_type=payload.get("target_type") or account.get("type"),
+            entity_id=account.get("id") or install.get("target_id"),
+            entity_name=account.get("login"),
+        )
         return f"installation_target.{action} logged"
 
     elif event == "workflow_job":
         action = payload["action"]
         wj_event = f"workflow_job.{action}"
 
+        # workflow_job's `installation` object is just `{id, node_id}` — no
+        # account info. Pull the entity from `repository.owner` instead.
+        wj_install = payload.get("installation") or {}
+        wj_owner = (payload.get("repository") or {}).get("owner") or {}
+        wj_log = dict(
+            payload=payload,
+            app_id=app_id,
+            installation_id=wj_install.get("id"),
+            entity_type=wj_owner.get("type"),
+            entity_id=wj_owner.get("id"),
+            entity_name=wj_owner.get("login"),
+        )
+
         # Ignore workflow_job actions we don't process (e.g. 'waiting').
         if action not in ("queued", "in_progress", "completed"):
-            _log_webhook_event(event=wj_event, outcome="ignored_action", **log_ctx)
+            _log_webhook_event(event=wj_event, outcome="ignored_action", **wj_log)
             logger.debug("Ignoring action: %s", action)
             return f"Ignoring action: {action}"
 
@@ -433,6 +463,8 @@ def webhook():
 
         # entity_id: owner_id (org) for organizations, repo_id for personal accounts
         entity_id = owner_id if entity_type == EntityType.ORGANIZATION else repo_id
+        # The log row records the same `entity_id` `add_job` would store.
+        wj_log["entity_id"] = entity_id
 
         # Make sure the required labels are present; Filters out unsupported jobs early.
         # If labels don't match, log + return — the WebhookError gets caught here so we
@@ -440,7 +472,7 @@ def webhook():
         try:
             k8s_pool, k8s_image = match_labels_to_k8s(owner_id, repo_full_name, job_labels)
         except WebhookError as e:
-            _log_webhook_event(event=wj_event, outcome="ignored_no_label", **log_ctx)
+            _log_webhook_event(event=wj_event, outcome="ignored_no_label", **wj_log)
             raise
 
         logger.info("Received %s workflow_job id=%s name=%s repo=%s labels=%s entity_type=%s",
@@ -480,7 +512,7 @@ def webhook():
             )
 
             outcome = "job_stored" if stored else "job_already_exists"
-            _log_webhook_event(event=wj_event, outcome=outcome, **log_ctx)
+            _log_webhook_event(event=wj_event, outcome=outcome, **wj_log)
 
             if stored:
                 return f"Job {job_id} stored."
@@ -490,7 +522,7 @@ def webhook():
         elif action == "in_progress":
             prev_status = db.mark_job_running(job_id, payload["workflow_job"].get("runner_name"))
             outcome = "job_not_found" if prev_status is None else "job_marked_running"
-            _log_webhook_event(event=wj_event, outcome=outcome, **log_ctx)
+            _log_webhook_event(event=wj_event, outcome=outcome, **wj_log)
             if prev_status is None:
                 logger.warning("Job %s not found on in_progress event", job_id)
                 return f"Job {job_id} not found."
@@ -500,14 +532,14 @@ def webhook():
         elif action == "completed":
             prev_status = db.mark_job_completed(job_id, payload["workflow_job"].get("runner_name"))
             outcome = "job_not_found" if prev_status is None else "job_marked_completed"
-            _log_webhook_event(event=wj_event, outcome=outcome, **log_ctx)
+            _log_webhook_event(event=wj_event, outcome=outcome, **wj_log)
             if prev_status is None:
                 logger.warning("Job %s not found on completed event", job_id)
                 return f"Job {job_id} not found."
             return f"Job {job_id} completed (was {prev_status})."
 
     else:
-        _log_webhook_event(event=event, outcome="ignored_event", **log_ctx)
+        _log_webhook_event(event=event, outcome="ignored_event", payload=payload, app_id=app_id)
         return f"Ignoring {event} event"
 
 if __name__ == "__main__":

--- a/container/ghfe.py
+++ b/container/ghfe.py
@@ -102,8 +102,7 @@ def check_webhook_signature(headers, body):
     return event, body
 
 
-def _log_webhook_event(*, delivery_id, hook_target_id, event, payload,
-                       outcome, **overrides):
+def _log_webhook_event(*, hook_target_id, event, payload, outcome, **overrides):
     """Insert one installation_events row for a webhook delivery.
 
     `event` and `payload` are caller-built. The helper extracts
@@ -111,15 +110,20 @@ def _log_webhook_event(*, delivery_id, hook_target_id, event, payload,
     `hook_target_id` (X-GitHub-Hook-Installation-Target-Id, the delivering
     app's id) when `payload.installation.app_id` is absent — needed for
     workflow_job deliveries whose installation object is just a stub.
+    `entity_name` mirrors `add_job` semantics: the owner login, taken from
+    `installation.account.login` (or top-level `account.login` for
+    installation_target.renamed) and falling back to
+    `repository.owner.login` for workflow_job payloads.
     """
     install = payload.get("installation") or {}
     account = install.get("account") or payload.get("account") or {}
+    repo_owner = (payload.get("repository") or {}).get("owner") or {}
     fields = dict(
         installation_id=install.get("id"),
         app_id=install.get("app_id") or hook_target_id,
-        entity_type=install.get("target_type") or account.get("type"),
-        entity_id=install.get("target_id") or account.get("id"),
-        account_login=account.get("login"),
+        entity_type=install.get("target_type") or account.get("type") or repo_owner.get("type"),
+        entity_id=install.get("target_id") or account.get("id") or repo_owner.get("id"),
+        entity_name=account.get("login") or repo_owner.get("login"),
     )
     fields.update(overrides)
     try:
@@ -127,7 +131,6 @@ def _log_webhook_event(*, delivery_id, hook_target_id, event, payload,
             source="webhook",
             event=event,
             outcome=outcome,
-            delivery_id=delivery_id,
             payload=payload,
             **fields,
         )
@@ -364,9 +367,8 @@ def webhook():
         logger.debug("Invalid JSON payload")
         raise WebhookError(400, "Invalid JSON payload")
 
-    delivery_id = request.headers.get("X-GitHub-Delivery")
     hook_target_id = _parse_hook_target_id(request.headers)
-    log_ctx = {"delivery_id": delivery_id, "hook_target_id": hook_target_id, "payload": payload}
+    log_ctx = {"hook_target_id": hook_target_id, "payload": payload}
 
     if event == "ping":
         _log_webhook_event(event="ping", outcome="ok", **log_ctx)

--- a/container/ghfe.py
+++ b/container/ghfe.py
@@ -103,16 +103,17 @@ def check_webhook_signature(headers, body):
     return event, body
 
 
-def _log_webhook_event(*, event, outcome, payload, app_id,
-                       installation_id=None, entity_type=None,
-                       entity_id=None, entity_name=None):
-    """Insert one installation_events row for a webhook delivery.
-
-    All fields are passed explicitly by the caller (each branch of
-    `webhook()` knows the exact payload shape for its event type and does
-    its own extraction). The helper just normalises `source="webhook"` and
-    handles the exception logging.
-    """
+def _log_webhook_event(
+    *,
+    event: str,
+    outcome: WebhookOutcome,
+    payload: dict,
+    app_id: int,
+    installation_id: int | None = None,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    entity_name: str | None = None,
+) -> None:
     try:
         db.add_installation_event(
             source="webhook",
@@ -126,8 +127,6 @@ def _log_webhook_event(*, event, outcome, payload, app_id,
             entity_name=entity_name,
         )
     except Exception:
-        # Bubble up so the caller's transaction view is honest, but make sure
-        # the response logs the original event/outcome for debugging.
         logger.exception("Failed to record installation_events row event=%s outcome=%s", event, outcome)
         raise
 
@@ -154,8 +153,7 @@ def match_labels_to_k8s(org_id, repo_full_name, job_labels):
     """
     Map workflow job labels to a k8s pool name and container image.
 
-    Returns (k8s_pool, k8s_image) where k8s_pool is the board name string
-    used as k8s pool key and pod label.
+    Returns (k8s_pool, k8s_image) on a match, or None if no rule matches.
     """
     # Special case(s) for PyTorch org
     if org_id == PYTORCH_ORG_ID or (org_id == RISEPROJECT_DEV_ORG_ID and repo_full_name in ["riseproject-dev/pytorch", "riseproject-dev/executorch"]):
@@ -164,14 +162,14 @@ def match_labels_to_k8s(org_id, repo_full_name, job_labels):
         elif "ubuntu-24.04-riscv" in job_labels:
             return "scw-em-rv1", RUNNER_IMAGE_UBUNTU_24_04
         else:
-            raise WebhookError(200, f"Ignoring job: missing required platform label (got {job_labels}) for PyTorch org")
+            return None
 
     # Special case(s) for GGML org
     elif org_id == GGML_ORG_ORG_ID or (org_id == RISEPROJECT_DEV_ORG_ID and repo_full_name in ["riseproject-dev/llama.cpp", "riseproject-dev/llama.cpp-validation"]):
         if job_labels == ["ubuntu-24.04-riscv"]:
             return "cloudv10x-jupiter", RUNNER_IMAGE_UBUNTU_24_04
         else:
-            raise WebhookError(200, f"Ignoring job: missing required platform label (got {job_labels}) for GGML org")
+            return None
 
     # General cases
     elif job_labels == ["ubuntu-24.04-riscv"]:
@@ -180,7 +178,7 @@ def match_labels_to_k8s(org_id, repo_full_name, job_labels):
     # elif job_labels == ["ubuntu-26.04-riscv"]:
     #     return "scw-em-rv1", RUNNER_IMAGE_UBUNTU_26_04
 
-    raise WebhookError(200, f"Ignoring job: missing required platform label (got {job_labels})")
+    return None
 
 
 # --- Routes ---
@@ -353,79 +351,78 @@ def webhook():
         raise WebhookError(400, "Invalid X-GitHub-Hook-Installation-Target-Id header")
 
     if event == "ping":
-        _log_webhook_event(event="ping", outcome="ok", payload=payload, app_id=app_id)
+        _log_webhook_event(event="ping", outcome=WebhookOutcome.OK, payload=payload, app_id=app_id)
         return f"pong"
 
     elif event == "installation":
         action = payload["action"]
         install = payload["installation"]
-        account = install.get("account") or {}
+        account = install["account"]
         _log_webhook_event(
-            event=f"installation.{action}",
-            outcome="ok",
+            event=f"{event}.{action}",
+            outcome=WebhookOutcome.OK,
             payload=payload,
             app_id=app_id,
-            installation_id=install.get("id"),
-            entity_type=install.get("target_type") or account.get("type"),
-            entity_id=install.get("target_id") or account.get("id"),
-            entity_name=account.get("login"),
+            installation_id=install["id"],
+            entity_type=install["target_type"],
+            entity_id=install["target_id"],
+            entity_name=account["login"],
         )
-        return f"installation.{action} logged"
+        return f"{event}.{action} logged"
 
     elif event == "installation_repositories":
         action = payload["action"]
         install = payload["installation"]
-        account = install.get("account") or {}
+        account = install["account"]
         _log_webhook_event(
-            event=f"installation_repositories.{action}",
-            outcome="ok",
+            event=f"{event}.{action}",
+            outcome=WebhookOutcome.OK,
             payload=payload,
             app_id=app_id,
-            installation_id=install.get("id"),
-            entity_type=install.get("target_type") or account.get("type"),
-            entity_id=install.get("target_id") or account.get("id"),
-            entity_name=account.get("login"),
+            installation_id=install["id"],
+            entity_type=install["target_type"],
+            entity_id=install["target_id"],
+            entity_name=account["login"],
         )
-        return f"installation_repositories.{action} logged"
+        return f"{event}.{action} logged"
 
     elif event == "installation_target":
         action = payload["action"]
         # `installation_target.renamed` carries the new account at top level;
-        # `installation.account` would be the pre-rename name, which is the wrong one.
-        account = payload.get("account") or {}
-        install = payload.get("installation") or {}
+        # `installation.account` would be the pre-rename name.
+        account = payload["account"]
+        install = payload["installation"]
         _log_webhook_event(
-            event=f"installation_target.{action}",
-            outcome="ok",
+            event=f"{event}.{action}",
+            outcome=WebhookOutcome.OK,
             payload=payload,
             app_id=app_id,
-            installation_id=install.get("id"),
-            entity_type=payload.get("target_type") or account.get("type"),
-            entity_id=account.get("id") or install.get("target_id"),
-            entity_name=account.get("login"),
+            installation_id=install["id"],
+            entity_type=payload["target_type"],
+            entity_id=account["id"],
+            entity_name=account["login"],
         )
-        return f"installation_target.{action} logged"
+        return f"{event}.{action} logged"
 
     elif event == "workflow_job":
         action = payload["action"]
-        wj_event = f"workflow_job.{action}"
 
-        # workflow_job's `installation` object is just `{id, node_id}` — no
-        # account info. Pull the entity from `repository.owner` instead.
-        wj_install = payload.get("installation") or {}
-        wj_owner = (payload.get("repository") or {}).get("owner") or {}
-        wj_log = dict(
+        # workflow_job's `installation` object is just `{id, node_id}` — pull
+        # the entity from `repository.owner` instead.
+        install = payload["installation"]
+        owner = payload["repository"]["owner"]
+        log_fields = dict(
             payload=payload,
             app_id=app_id,
-            installation_id=wj_install.get("id"),
-            entity_type=wj_owner.get("type"),
-            entity_id=wj_owner.get("id"),
-            entity_name=wj_owner.get("login"),
+            installation_id=install["id"],
+            entity_type=owner["type"],
+            entity_id=owner["id"],
+            entity_name=owner["login"],
         )
 
         # Ignore workflow_job actions we don't process (e.g. 'waiting').
         if action not in ("queued", "in_progress", "completed"):
-            _log_webhook_event(event=wj_event, outcome="ignored_action", **wj_log)
+            _log_webhook_event(event=f"{event}.{action}", outcome=WebhookOutcome.IGNORED_ACTION, **log_fields)
             logger.debug("Ignoring action: %s", action)
             return f"Ignoring action: {action}"
 
@@ -461,19 +458,17 @@ def webhook():
         if not repo_id:
             raise WebhookError(400, "Repository ID is missing in payload")
 
-        # entity_id: owner_id (org) for organizations, repo_id for personal accounts
-        entity_id = owner_id if entity_type == EntityType.ORGANIZATION else repo_id
+        # entity_id: owner_id (org) for organizations, repo_id for personal accounts.
         # The log row records the same `entity_id` `add_job` would store.
-        wj_log["entity_id"] = entity_id
+        entity_id = owner_id if entity_type == EntityType.ORGANIZATION else repo_id
+        log_fields["entity_id"] = entity_id
 
-        # Make sure the required labels are present; Filters out unsupported jobs early.
-        # If labels don't match, log + return — the WebhookError gets caught here so we
-        # can still record an `ignored_no_label` row before propagating the response.
-        try:
-            k8s_pool, k8s_image = match_labels_to_k8s(owner_id, repo_full_name, job_labels)
-        except WebhookError as e:
-            _log_webhook_event(event=wj_event, outcome="ignored_no_label", **wj_log)
-            raise
+        # Filter out unsupported jobs early.
+        match = match_labels_to_k8s(owner_id, repo_full_name, job_labels)
+        if match is None:
+            _log_webhook_event(event=f"{event}.{action}", outcome=WebhookOutcome.IGNORED_NO_LABEL, **log_fields)
+            raise WebhookError(200, f"Ignoring job: missing required platform label (got {job_labels})")
+        k8s_pool, k8s_image = match
 
         logger.info("Received %s workflow_job id=%s name=%s repo=%s labels=%s entity_type=%s",
                     action, job_id, payload["workflow_job"]["name"],
@@ -511,8 +506,8 @@ def webhook():
                 html_url=html_url,
             )
 
-            outcome = "job_stored" if stored else "job_already_exists"
-            _log_webhook_event(event=wj_event, outcome=outcome, **wj_log)
+            outcome = WebhookOutcome.JOB_STORED if stored else WebhookOutcome.JOB_ALREADY_EXISTS
+            _log_webhook_event(event=f"{event}.{action}", outcome=outcome, **log_fields)
 
             if stored:
                 return f"Job {job_id} stored."
@@ -521,8 +516,8 @@ def webhook():
 
         elif action == "in_progress":
             prev_status = db.mark_job_running(job_id, payload["workflow_job"].get("runner_name"))
-            outcome = "job_not_found" if prev_status is None else "job_marked_running"
-            _log_webhook_event(event=wj_event, outcome=outcome, **wj_log)
+            outcome = WebhookOutcome.JOB_NOT_FOUND if prev_status is None else WebhookOutcome.JOB_MARKED_RUNNING
+            _log_webhook_event(event=f"{event}.{action}", outcome=outcome, **log_fields)
             if prev_status is None:
                 logger.warning("Job %s not found on in_progress event", job_id)
                 return f"Job {job_id} not found."
@@ -531,15 +526,15 @@ def webhook():
 
         elif action == "completed":
             prev_status = db.mark_job_completed(job_id, payload["workflow_job"].get("runner_name"))
-            outcome = "job_not_found" if prev_status is None else "job_marked_completed"
-            _log_webhook_event(event=wj_event, outcome=outcome, **wj_log)
+            outcome = WebhookOutcome.JOB_NOT_FOUND if prev_status is None else WebhookOutcome.JOB_MARKED_COMPLETED
+            _log_webhook_event(event=f"{event}.{action}", outcome=outcome, **log_fields)
             if prev_status is None:
                 logger.warning("Job %s not found on completed event", job_id)
                 return f"Job {job_id} not found."
             return f"Job {job_id} completed (was {prev_status})."
 
     else:
-        _log_webhook_event(event=event, outcome="ignored_event", payload=payload, app_id=app_id)
+        _log_webhook_event(event=event, outcome=WebhookOutcome.IGNORED_EVENT, payload=payload, app_id=app_id)
         return f"Ignoring {event} event"
 
 if __name__ == "__main__":

--- a/container/github.py
+++ b/container/github.py
@@ -44,16 +44,19 @@ def generate_jwt(app_id, private_key):
 
 
 @ttl_cache(maxsize=1024, ttl=60*59) # Authentication Token lifetime is 1 hour
-def authenticate_app(installation_id, entity_type):
+def authenticate_app(installation_id, app_id):
     """Authenticate the app and get an installation token.
 
-    Uses the org GitHub App for organizations, personal GitHub App for users.
+    `app_id` selects which app's private key signs the JWT — pass
+    `GHAPP_PERSONAL_ID` for user installations, `GHAPP_ORG_ID` for org
+    installations.
     """
-    assert entity_type is not None
-    if entity_type == EntityType.USER:
+    if app_id == GHAPP_PERSONAL_ID:
         jwt_token = generate_jwt(GHAPP_PERSONAL_ID, init_ghapp_private_key_personal())
-    else:
+    elif app_id == GHAPP_ORG_ID:
         jwt_token = generate_jwt(GHAPP_ORG_ID, init_ghapp_private_key_org())
+    else:
+        raise ValueError(f"Unknown app_id: {app_id}")
 
     headers = {
         "Authorization": f"Bearer {jwt_token}",

--- a/container/scheduler.py
+++ b/container/scheduler.py
@@ -26,6 +26,55 @@ logger = logging.getLogger(__name__)
 
 POLL_INTERVAL = 15
 
+
+def _gh_authenticate_app(installation_id, entity_type, *, job_id=None,
+                         repo_full_name=None, repo_id=None,
+                         entity_id=None, account_login=None):
+    """Wrap gh.authenticate_app and log every failure to installation_events.
+
+    Successful auths are not logged (gh.authenticate_app's @ttl_cache makes
+    success a hot path). Only GitHubAPIError failures are recorded — the
+    cache itself doesn't store exceptions, so transient errors won't poison
+    subsequent calls.
+    """
+    try:
+        return gh.authenticate_app(int(installation_id), entity_type=entity_type)
+    except gh.GitHubAPIError as e:
+        app_id = GHAPP_PERSONAL_ID if entity_type == EntityType.USER else GHAPP_ORG_ID
+        outcome = "auth_404" if e.status_code == 404 else "auth_other_error"
+        event_str = (f"auth_attempt.{e.status_code}"
+                     if e.status_code == 404
+                     else "auth_attempt.other_error")
+        synthetic_payload = {
+            "installation_id": int(installation_id),
+            "app_id": app_id,
+            "entity_type": entity_type.value,
+            "entity_id": entity_id,
+            "account_login": account_login,
+            "repository": ({"id": repo_id, "full_name": repo_full_name}
+                           if repo_full_name else None),
+            "workflow_job": {"id": job_id} if job_id else None,
+            "http_status": e.status_code,
+            "error_message": str(e),
+        }
+        try:
+            db.add_installation_event(
+                source="scheduler",
+                event=event_str,
+                outcome=outcome,
+                installation_id=int(installation_id),
+                app_id=app_id,
+                entity_type=entity_type.value,
+                entity_id=entity_id,
+                account_login=account_login,
+                payload=synthetic_payload,
+            )
+        except Exception:
+            logger.exception("Failed to record auth_attempt event_str=%s installation_id=%s",
+                             event_str, installation_id)
+        raise
+
+
 def sync_jobs_state():
     """
     Sync job status between GitHub and the jobs table.
@@ -50,7 +99,13 @@ def sync_jobs_state():
             continue
 
         try:
-            token = gh.authenticate_app(int(installation_id), entity_type=entity_type)
+            token = _gh_authenticate_app(
+                int(installation_id), entity_type=entity_type,
+                job_id=job_id,
+                repo_full_name=repo,
+                entity_id=job.get("entity_id"),
+                account_login=job.get("entity_name"),
+            )
         except gh.GitHubAPIError as e:
             if e.status_code == 404:
                 logger.warning("Installation not found installation_id=%s entity_type=%s, marking job %s failed",
@@ -225,7 +280,12 @@ def _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_
     for gh_runner_key, workers in workers_by_gh_runner_key:
         installation_id, entity_type, entity_id, gh_runner_target = gh_runner_key
         try:
-            token = gh.authenticate_app(installation_id, entity_type=entity_type)
+            token = _gh_authenticate_app(
+                installation_id, entity_type=entity_type,
+                entity_id=entity_id,
+                account_login=(gh_runner_target if entity_type == EntityType.ORGANIZATION else None),
+                repo_full_name=(gh_runner_target if entity_type == EntityType.USER else None),
+            )
         except gh.GitHubAPIError as e:
             logger.error("Failed to authenticate for installation_id=%s entity_type=%s gh_runner_target=%s: %s", installation_id, entity_type, gh_runner_target, e)
             continue
@@ -320,9 +380,14 @@ def _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target
     gets deleted on GitHub. Reads the cache populated by Phase 3.
     """
     for gh_runner_key, gh_runners in gh_runners_by_target.items():
-        installation_id, entity_type, _, gh_runner_target = gh_runner_key
+        installation_id, entity_type, entity_id, gh_runner_target = gh_runner_key
         try:
-            token = gh.authenticate_app(installation_id, entity_type=entity_type)
+            token = _gh_authenticate_app(
+                installation_id, entity_type=entity_type,
+                entity_id=entity_id,
+                account_login=(gh_runner_target if entity_type == EntityType.ORGANIZATION else None),
+                repo_full_name=(gh_runner_target if entity_type == EntityType.USER else None),
+            )
         except gh.GitHubAPIError as e:
             logger.error("Failed to authenticate for installation_id=%s entity_type=%s gh_runner_target=%s: %s", installation_id, entity_type, gh_runner_target, e)
             continue
@@ -481,7 +546,12 @@ def demand_match():
 
             # Name reserved in DB, now safe to provision
             try:
-                token = gh.authenticate_app(int(installation_id), entity_type=entity_type)
+                token = _gh_authenticate_app(
+                    int(installation_id), entity_type=entity_type,
+                    entity_id=entity_id,
+                    account_login=entity_name,
+                    repo_full_name=repo_full_name,
+                )
 
                 if entity_type == EntityType.ORGANIZATION:
                     group_id = gh.ensure_runner_group(entity_name, token, RUNNER_GROUP_NAME)

--- a/container/scheduler.py
+++ b/container/scheduler.py
@@ -103,8 +103,8 @@ def sync_jobs_state():
                 int(installation_id), entity_type=entity_type,
                 job_id=job_id,
                 repo_full_name=repo,
-                entity_id=job.get("entity_id"),
-                entity_name=job.get("entity_name"),
+                entity_id=job["entity_id"],
+                entity_name=job["entity_name"],
             )
         except gh.GitHubAPIError as e:
             if e.status_code == 404:

--- a/container/scheduler.py
+++ b/container/scheduler.py
@@ -29,7 +29,7 @@ POLL_INTERVAL = 15
 
 def _gh_authenticate_app(installation_id, entity_type, *, job_id=None,
                          repo_full_name=None, repo_id=None,
-                         entity_id=None, account_login=None):
+                         entity_id=None, entity_name=None):
     """Wrap gh.authenticate_app and log every failure to installation_events.
 
     Successful auths are not logged (gh.authenticate_app's @ttl_cache makes
@@ -50,7 +50,7 @@ def _gh_authenticate_app(installation_id, entity_type, *, job_id=None,
             "app_id": app_id,
             "entity_type": entity_type.value,
             "entity_id": entity_id,
-            "account_login": account_login,
+            "entity_name": entity_name,
             "repository": ({"id": repo_id, "full_name": repo_full_name}
                            if repo_full_name else None),
             "workflow_job": {"id": job_id} if job_id else None,
@@ -66,7 +66,7 @@ def _gh_authenticate_app(installation_id, entity_type, *, job_id=None,
                 app_id=app_id,
                 entity_type=entity_type.value,
                 entity_id=entity_id,
-                account_login=account_login,
+                entity_name=entity_name,
                 payload=synthetic_payload,
             )
         except Exception:
@@ -104,7 +104,7 @@ def sync_jobs_state():
                 job_id=job_id,
                 repo_full_name=repo,
                 entity_id=job.get("entity_id"),
-                account_login=job.get("entity_name"),
+                entity_name=job.get("entity_name"),
             )
         except gh.GitHubAPIError as e:
             if e.status_code == 404:
@@ -283,7 +283,7 @@ def _sync_workers_state_phase_3_health_checks(pods_by_name, workers_by_name, gh_
             token = _gh_authenticate_app(
                 installation_id, entity_type=entity_type,
                 entity_id=entity_id,
-                account_login=(gh_runner_target if entity_type == EntityType.ORGANIZATION else None),
+                entity_name=(gh_runner_target if entity_type == EntityType.ORGANIZATION else None),
                 repo_full_name=(gh_runner_target if entity_type == EntityType.USER else None),
             )
         except gh.GitHubAPIError as e:
@@ -385,7 +385,7 @@ def _sync_workers_state_phase_4_gh_cleanup(workers_by_name, gh_runners_by_target
             token = _gh_authenticate_app(
                 installation_id, entity_type=entity_type,
                 entity_id=entity_id,
-                account_login=(gh_runner_target if entity_type == EntityType.ORGANIZATION else None),
+                entity_name=(gh_runner_target if entity_type == EntityType.ORGANIZATION else None),
                 repo_full_name=(gh_runner_target if entity_type == EntityType.USER else None),
             )
         except gh.GitHubAPIError as e:
@@ -549,7 +549,7 @@ def demand_match():
                 token = _gh_authenticate_app(
                     int(installation_id), entity_type=entity_type,
                     entity_id=entity_id,
-                    account_login=entity_name,
+                    entity_name=entity_name,
                     repo_full_name=repo_full_name,
                 )
 

--- a/container/scheduler.py
+++ b/container/scheduler.py
@@ -37,11 +37,11 @@ def _gh_authenticate_app(installation_id, entity_type, *, job_id=None,
     cache itself doesn't store exceptions, so transient errors won't poison
     subsequent calls.
     """
+    app_id = GHAPP_PERSONAL_ID if entity_type == EntityType.USER else GHAPP_ORG_ID
     try:
-        return gh.authenticate_app(int(installation_id), entity_type=entity_type)
+        return gh.authenticate_app(int(installation_id), app_id)
     except gh.GitHubAPIError as e:
-        app_id = GHAPP_PERSONAL_ID if entity_type == EntityType.USER else GHAPP_ORG_ID
-        outcome = "auth_404" if e.status_code == 404 else "auth_other_error"
+        outcome = WebhookOutcome.AUTH_404 if e.status_code == 404 else WebhookOutcome.AUTH_OTHER_ERROR
         event_str = (f"auth_attempt.{e.status_code}"
                      if e.status_code == 404
                      else "auth_attempt.other_error")

--- a/scripts/trace_installation.py
+++ b/scripts/trace_installation.py
@@ -72,14 +72,14 @@ def _short(s: str | None, n: int) -> str:
 
 def render_table(events: list[dict]) -> None:
     """Print a chronological table — one row per event."""
-    cols = ("received_at", "event", "outcome", "repo_full_name", "job_id", "delivery_id")
+    cols = ("received_at", "event", "outcome", "entity_name", "repo_full_name", "job_id")
     widths = {
         "received_at": 26,
         "event": 36,
         "outcome": 22,
+        "entity_name": 24,
         "repo_full_name": 36,
         "job_id": 14,
-        "delivery_id": 36,
     }
     header = "  ".join(f"{c:<{widths[c]}}" for c in cols)
     print(header)
@@ -89,9 +89,9 @@ def render_table(events: list[dict]) -> None:
             "received_at": _short(e.get("received_at"), widths["received_at"]),
             "event": _short(e.get("event"), widths["event"]),
             "outcome": _short(e.get("outcome"), widths["outcome"]),
+            "entity_name": _short(e.get("entity_name"), widths["entity_name"]),
             "repo_full_name": _short(e.get("repo_full_name"), widths["repo_full_name"]),
             "job_id": _short(e.get("job_id"), widths["job_id"]),
-            "delivery_id": _short(e.get("delivery_id"), widths["delivery_id"]),
         }
         print("  ".join(f"{row[c]:<{widths[c]}}" for c in cols))
 

--- a/scripts/trace_installation.py
+++ b/scripts/trace_installation.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Reconstruct GitHub App installation history for an entity.
+
+Pulls events from /trace/* on the production GHFE and prints a chronological
+table — used to debug "installation not found" cases (jobs that never get
+picked up). The PROD_URL is hard-coded; TRACE_API_TOKEN comes from the
+environment.
+
+For --entity-name <login>, this script shells out to `gh api` to resolve the
+login to a numeric account.id (User then Org). Requires `gh auth login`.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+import requests
+
+
+PROD_URL = "https://riseriscvrunnerappqdvknz9s-ghfe.functions.fnc.fr-par.scw.cloud"
+TRACE_API_TOKEN = os.environ["TRACE_API_TOKEN"]
+
+PAYLOAD_DUMP_LIMIT = 4 * 1024  # bytes — truncate verbose payload dumps for terminal
+
+
+def _api_get(path: str) -> dict:
+    """GET PROD_URL + path with the bearer token. Raises on non-2xx."""
+    url = PROD_URL.rstrip("/") + path
+    resp = requests.get(url, headers={"Authorization": f"Bearer {TRACE_API_TOKEN}"}, timeout=30)
+    if resp.status_code != 200:
+        sys.exit(f"GET {url} -> {resp.status_code}: {resp.text}")
+    return resp.json()
+
+
+def resolve_entity_name(login: str) -> int:
+    """`gh api /users/<login>` then fall back to `/orgs/<login>`. Returns account.id."""
+    for path in (f"/users/{login}", f"/orgs/{login}"):
+        result = subprocess.run(
+            ["gh", "api", path, "--jq", ".id"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return int(result.stdout.strip())
+    sys.exit(f"could not resolve entity name {login!r} via `gh api`. Have you run `gh auth login`?")
+
+
+def fetch_events(args: argparse.Namespace) -> list[dict]:
+    if args.installation_id is not None:
+        return _api_get(f"/trace/installation/{args.installation_id}")["events"]
+    if args.entity_id is not None:
+        return _api_get(f"/trace/entity/{args.entity_id}")["events"]
+    if args.entity_name is not None:
+        return _api_get(f"/trace/entity/{resolve_entity_name(args.entity_name)}")["events"]
+    if args.job_id is not None:
+        return _api_get(f"/trace/job/{args.job_id}")["events"]
+    sys.exit("internal error: no selector provided")
+
+
+def fetch_payload(event_id: int) -> Any:
+    return _api_get(f"/trace/payload/{event_id}").get("payload")
+
+
+def _short(s: str | None, n: int) -> str:
+    if s is None:
+        return ""
+    s = str(s)
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def render_table(events: list[dict]) -> None:
+    """Print a chronological table — one row per event."""
+    cols = ("received_at", "event", "outcome", "repo_full_name", "job_id", "delivery_id")
+    widths = {
+        "received_at": 26,
+        "event": 36,
+        "outcome": 22,
+        "repo_full_name": 36,
+        "job_id": 14,
+        "delivery_id": 36,
+    }
+    header = "  ".join(f"{c:<{widths[c]}}" for c in cols)
+    print(header)
+    print("-" * len(header))
+    for e in events:
+        row = {
+            "received_at": _short(e.get("received_at"), widths["received_at"]),
+            "event": _short(e.get("event"), widths["event"]),
+            "outcome": _short(e.get("outcome"), widths["outcome"]),
+            "repo_full_name": _short(e.get("repo_full_name"), widths["repo_full_name"]),
+            "job_id": _short(e.get("job_id"), widths["job_id"]),
+            "delivery_id": _short(e.get("delivery_id"), widths["delivery_id"]),
+        }
+        print("  ".join(f"{row[c]:<{widths[c]}}" for c in cols))
+
+
+def render_verbose_auth_payloads(events: list[dict]) -> None:
+    """For each auth_attempt.* row, fetch and dump its payload (truncated)."""
+    for e in events:
+        if not (e.get("event") or "").startswith("auth_attempt."):
+            continue
+        payload = fetch_payload(int(e["id"]))
+        text = json.dumps(payload, indent=2, default=str)
+        if len(text) > PAYLOAD_DUMP_LIMIT:
+            text = text[:PAYLOAD_DUMP_LIMIT] + "\n  …(truncated)"
+        print(f"\n=== payload for event id={e['id']} ({e.get('event')}) ===")
+        print(text)
+
+
+def diagnosis(events: list[dict]) -> list[str]:
+    """Heuristics over the event stream. Returns human-readable hint lines."""
+    hints: list[str] = []
+
+    # 1. Suspended without subsequent unsuspend
+    last_suspend = None
+    last_unsuspend = None
+    last_deleted = None
+    last_renamed = None
+    has_selected = False
+    for e in events:
+        ev = e.get("event")
+        ts = e.get("received_at")
+        if ev == "installation.suspend":
+            last_suspend = ts
+        elif ev == "installation.unsuspend":
+            last_unsuspend = ts
+        elif ev == "installation.deleted":
+            last_deleted = ts
+        elif ev == "installation_target.renamed":
+            last_renamed = ts
+
+    if last_suspend and (last_unsuspend is None or last_unsuspend < last_suspend):
+        hints.append(f"Installation is currently suspended (last suspend at {last_suspend}).")
+    if last_deleted:
+        hints.append(f"App was uninstalled at {last_deleted} — installation_id no longer valid.")
+    if last_renamed:
+        hints.append(f"Account was renamed at {last_renamed} — cached entity_name on jobs may be stale.")
+
+    # 2. auth_attempt.404 anywhere is a strong signal
+    auth_404 = [e for e in events if e.get("event") == "auth_attempt.404"]
+    if auth_404:
+        hints.append(f"{len(auth_404)} auth_attempt.404 row(s) — installation lookup failed during scheduler reconcile.")
+
+    return hints
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--installation-id", type=int)
+    g.add_argument("--entity-id", type=int)
+    g.add_argument("--entity-name", type=str, help="GitHub login; resolved via `gh api`")
+    g.add_argument("--job-id", type=int)
+    p.add_argument("--verbose", action="store_true",
+                   help="dump full payload for auth_attempt.* rows")
+    p.add_argument("--json", action="store_true", help="dump raw events as JSON")
+    args = p.parse_args()
+
+    events = fetch_events(args)
+
+    if args.json:
+        print(json.dumps(events, indent=2, default=str))
+        return 0
+
+    if not events:
+        print("No events found.")
+        return 0
+
+    render_table(events)
+
+    if args.verbose:
+        render_verbose_auth_payloads(events)
+
+    hints = diagnosis(events)
+    if hints:
+        print("\nDiagnosis hints:")
+        for h in hints:
+            print(f"  - {h}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ mock_constants.GHAPP_ORG_PRIVATE_KEY = "test-key"
 mock_constants.GHAPP_PERSONAL_ID = 3131217
 mock_constants.GHAPP_PERSONAL_PRIVATE_KEY = "test-key-personal"
 mock_constants.GHAPP_WEBHOOK_SECRET = "test-webhook-secret"
+mock_constants.TRACE_API_TOKEN = "test-trace-token"
 mock_constants.POSTGRES_URL = "postgresql://test:test@localhost:5432/testdb"
 mock_constants.POSTGRES_SCHEMA = "staging"
 mock_constants.POSTGRES_MAXCONN = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,26 @@ class EntityType(str, Enum):
     ORGANIZATION = "Organization"
     USER = "User"
 
+
+class WebhookOutcome(str, Enum):
+    OK = "ok"
+    JOB_STORED = "job_stored"
+    JOB_ALREADY_EXISTS = "job_already_exists"
+    JOB_MARKED_RUNNING = "job_marked_running"
+    JOB_MARKED_COMPLETED = "job_marked_completed"
+    JOB_NOT_FOUND = "job_not_found"
+    IGNORED_ACTION = "ignored_action"
+    IGNORED_NO_LABEL = "ignored_no_label"
+    IGNORED_EVENT = "ignored_event"
+    AUTH_404 = "auth_404"
+    AUTH_OTHER_ERROR = "auth_other_error"
+
+
 # Mock the constants module before any container module is imported.
 # This avoids requiring real env vars (PROD, PROD_URL, etc.) during tests.
 mock_constants = types.ModuleType("constants")
 mock_constants.EntityType = EntityType
+mock_constants.WebhookOutcome = WebhookOutcome
 mock_constants.PROD = False
 mock_constants.PROD_URL = "https://prod.example.com"
 mock_constants.STAGING_URL = "https://staging.example.com"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -479,12 +479,11 @@ def test_add_installation_event_inserts_row(mock_pool_fn):
         source="webhook",
         event="installation.created",
         outcome="ok",
-        delivery_id="11111111-2222-3333-4444-555555555555",
         installation_id=999,
         app_id=2167633,
         entity_type="Organization",
         entity_id=152654596,
-        account_login="riseproject-dev",
+        entity_name="riseproject-dev",
         payload={"installation": {"id": 999}, "action": "created"},
     )
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,6 +6,11 @@ import pytest
 
 from db import (
     add_job,
+    add_installation_event,
+    get_events_by_entity_id,
+    get_payload_by_id,
+    get_entity_id_for_installation,
+    get_entity_id_for_job,
     mark_job_running,
     mark_job_completed,
     mark_job_failed,
@@ -460,3 +465,187 @@ def test_get_all_workers_with_paging(mock_pool_fn):
     params = select_call[0][1]
     assert params[-2] == 10  # per_page (LIMIT)
     assert params[-1] == 10  # page * per_page (OFFSET)
+
+
+# --- installation_events ---
+
+@patch("db._init_pool")
+def test_add_installation_event_inserts_row(mock_pool_fn):
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = (42,)
+
+    new_id = add_installation_event(
+        source="webhook",
+        event="installation.created",
+        outcome="ok",
+        delivery_id="11111111-2222-3333-4444-555555555555",
+        installation_id=999,
+        app_id=2167633,
+        entity_type="Organization",
+        entity_id=152654596,
+        account_login="riseproject-dev",
+        payload={"installation": {"id": 999}, "action": "created"},
+    )
+
+    assert new_id == 42
+    # SET search_path + INSERT … RETURNING id
+    insert_call = cur.execute.call_args_list[1]
+    sql, params = insert_call[0]
+    assert "INSERT INTO installation_events" in sql
+    assert "RETURNING id" in sql
+    # payload is the last positional placeholder, JSON-serialised
+    assert json.loads(params[-1]) == {"installation": {"id": 999}, "action": "created"}
+
+
+def test_add_installation_event_payload_required():
+    with pytest.raises(TypeError):
+        add_installation_event(
+            source="webhook",
+            event="ping",
+            outcome="ok",
+        )
+
+
+@patch("db._init_pool")
+def test_add_installation_event_minimal_payload(mock_pool_fn):
+    """payload={} must be accepted (the helper enforces non-None, not non-empty)."""
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = (7,)
+
+    new_id = add_installation_event(
+        source="scheduler",
+        event="auth_attempt.404",
+        outcome="auth_404",
+        installation_id=999,
+        payload={},
+    )
+    assert new_id == 7
+    insert_call = cur.execute.call_args_list[1]
+    params = insert_call[0][1]
+    assert params[-1] == "{}"
+
+
+def test_add_installation_event_rejects_none_payload():
+    with pytest.raises(AssertionError):
+        add_installation_event(
+            source="webhook",
+            event="ping",
+            outcome="ok",
+            payload=None,
+        )
+
+
+@patch("db._init_pool")
+def test_get_events_by_entity_id_strips_workflow_payload(mock_pool_fn):
+    """SQL must NOT project `payload`, must extract job_id/repo_full_name only for
+    workflow_job.* rows."""
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchall.return_value = [
+        {"id": 1, "event": "installation.created", "job_id": None, "repo_full_name": None},
+        {"id": 2, "event": "workflow_job.queued", "job_id": "12345",
+         "repo_full_name": "org/repo"},
+    ]
+
+    rows = get_events_by_entity_id(152654596)
+
+    assert len(rows) == 2
+    # SET search_path + SELECT
+    select_sql = cur.execute.call_args_list[1][0][0]
+    assert "FROM installation_events" in select_sql
+    assert "WHERE entity_id = %s" in select_sql
+    # Workflow_job extraction in SQL
+    assert "workflow_job" in select_sql
+    assert "repository" in select_sql
+    # `payload` itself is NOT in the SELECT list
+    select_list = select_sql.split("FROM")[0]
+    assert " payload " not in select_list and " payload\n" not in select_list
+
+
+@patch("db._init_pool")
+def test_get_payload_by_id_returns_only_payload(mock_pool_fn):
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = ({"action": "created"},)
+
+    p = get_payload_by_id(42)
+    assert p == {"action": "created"}
+    select_sql = cur.execute.call_args_list[1][0][0]
+    # Only `payload` is projected, no other columns
+    assert "SELECT payload FROM installation_events" in select_sql
+    assert "WHERE id = %s" in select_sql
+
+
+@patch("db._init_pool")
+def test_get_payload_by_id_not_found(mock_pool_fn):
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = None
+    assert get_payload_by_id(42) is None
+
+
+@patch("db._init_pool")
+def test_get_entity_id_for_job_uses_jobs_table(mock_pool_fn):
+    """Must hit jobs.entity_id directly — one query, not two."""
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = (152654596,)
+
+    eid = get_entity_id_for_job(12345)
+
+    assert eid == 152654596
+    # SET search_path + the lookup SELECT
+    assert cur.execute.call_count == 2
+    select_sql = cur.execute.call_args_list[1][0][0]
+    assert "SELECT entity_id FROM jobs" in select_sql
+
+
+@patch("db._init_pool")
+def test_get_entity_id_for_job_not_found(mock_pool_fn):
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = None
+    assert get_entity_id_for_job(999) is None
+
+
+@patch("db._init_pool")
+def test_get_entity_id_for_installation_from_events(mock_pool_fn):
+    """When installation_events has a matching row, use its entity_id (no fallback)."""
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.return_value = (152654596,)  # first SELECT hits installation_events
+
+    eid = get_entity_id_for_installation(999)
+
+    assert eid == 152654596
+    # SET search_path + one SELECT (no fallback needed)
+    assert cur.execute.call_count == 2
+    sql = cur.execute.call_args_list[1][0][0]
+    assert "FROM installation_events" in sql
+
+
+@patch("db._init_pool")
+def test_get_entity_id_for_installation_falls_back_to_jobs(mock_pool_fn):
+    """When installation_events has no matching row, fall back to jobs."""
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.side_effect = [None, (152654596,)]  # events miss, jobs hit
+
+    eid = get_entity_id_for_installation(999)
+
+    assert eid == 152654596
+    # SET search_path + events SELECT + jobs SELECT
+    assert cur.execute.call_count == 3
+    fallback_sql = cur.execute.call_args_list[2][0][0]
+    assert "FROM jobs" in fallback_sql
+
+
+@patch("db._init_pool")
+def test_get_entity_id_for_installation_not_found_anywhere(mock_pool_fn):
+    pool, conn, cur = make_mock_pool()
+    mock_pool_fn.return_value = pool
+    cur.fetchone.side_effect = [None, None]
+    assert get_entity_id_for_installation(999) is None
+

--- a/tests/test_ghfe.py
+++ b/tests/test_ghfe.py
@@ -6,12 +6,23 @@ from constants import EntityType
 from ghfe import (
     WebhookError,
     check_webhook_signature,
-    check_webhook_event,
     authorize_entity,
     compute_signature,
     match_labels_to_k8s,
     GHAPP_WEBHOOK_SECRET,
+    TRACE_API_TOKEN,
 )
+
+
+@pytest.fixture(autouse=True)
+def _mock_add_installation_event():
+    """Stub the event log writer so webhook tests don't try to hit Postgres.
+
+    Returns a fresh MagicMock per test; tests that care about the call args
+    can grab it via the request fixture if needed.
+    """
+    with patch("ghfe.db.add_installation_event", return_value=1) as m:
+        yield m
 
 
 # --- Signature verification ---
@@ -44,40 +55,6 @@ def test_missing_signature():
         with pytest.raises(WebhookError) as exc:
             check_webhook_signature(headers, "")
         assert exc.value.status_code == 400
-
-
-# --- Event parsing ---
-
-def test_queued_event():
-    body = json.dumps({"action": "queued", "workflow_job": {"id": 1, "name": "test", "labels": ["ubuntu-24.04-riscv"]}, "repository": {"full_name": "org/repo"}})
-    payload, action = check_webhook_event(body)
-    assert action == "queued"
-
-
-def test_completed_event():
-    body = json.dumps({"action": "completed", "workflow_job": {"id": 123, "name": "test", "labels": ["ubuntu-24.04-riscv"]}, "repository": {"full_name": "org/repo"}})
-    payload, action = check_webhook_event(body)
-    assert action == "completed"
-
-
-def test_in_progress_event():
-    body = json.dumps({"action": "in_progress", "workflow_job": {"id": 123, "name": "test", "labels": ["ubuntu-24.04-riscv"]}, "repository": {"full_name": "org/repo"}})
-    payload, action = check_webhook_event(body)
-    assert action == "in_progress"
-
-
-def test_ignored_event():
-    body = '{"action":"waiting"}'
-    with pytest.raises(WebhookError) as exc:
-        check_webhook_event(body)
-    assert exc.value.status_code == 200
-    assert "Ignoring action" in exc.value.message
-
-
-def test_invalid_json():
-    with pytest.raises(WebhookError) as exc:
-        check_webhook_event("{")
-    assert exc.value.status_code == 400
 
 
 # --- Owner authorization ---
@@ -330,3 +307,392 @@ def test_setup_upstream_error(mock_get_installation):
         resp = client.get("/setup/org?installation_id=123")
         assert resp.status_code == 502
         assert b"Something went wrong" in resp.data
+
+
+# --- Installation event logging on the webhook handler ---
+
+DELIVERY_HEADERS = {
+    "X-GitHub-Delivery": "11111111-2222-3333-4444-555555555555",
+    "X-GitHub-Hook-Installation-Target-Id": "2167633",
+}
+
+
+def _post_webhook(client, body, event):
+    sig = "sha256=" + compute_signature(body, GHAPP_WEBHOOK_SECRET).hexdigest()
+    headers = {
+        "X-Hub-Signature-256": sig,
+        "X-Github-Event": event,
+        "Content-Type": "application/json",
+        **DELIVERY_HEADERS,
+    }
+    return client.post("/", data=body, headers=headers)
+
+
+def _last_log_call(mock):
+    """Return the kwargs of the last call to db.add_installation_event."""
+    assert mock.call_count >= 1, "expected db.add_installation_event to be called"
+    return mock.call_args.kwargs
+
+
+def test_webhook_invalid_json_returns_400(_mock_add_installation_event):
+    from ghfe import app
+    body = "{not-json"
+    sig = "sha256=" + compute_signature(body, GHAPP_WEBHOOK_SECRET).hexdigest()
+    with app.test_client() as client:
+        resp = client.post("/", data=body, headers={
+            "X-Hub-Signature-256": sig,
+            "X-Github-Event": "installation",
+            "Content-Type": "application/json",
+        })
+        assert resp.status_code == 400
+
+
+def test_webhook_ping_logs_ok(_mock_add_installation_event):
+    from ghfe import app
+    body = json.dumps({"zen": "Approachable is better than simple."})
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "ping")
+        assert resp.status_code == 200
+        assert resp.data == b"pong"
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "ping"
+    assert kwargs["outcome"] == "ok"
+    assert kwargs["source"] == "webhook"
+
+
+def test_webhook_installation_created_logs(_mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "created",
+        "installation": {
+            "id": 999,
+            "app_id": 2167633,
+            "target_id": 152654596,
+            "target_type": "Organization",
+            "account": {"id": 152654596, "login": "riseproject-dev", "type": "Organization"},
+        },
+        "repositories": [{"id": 1, "full_name": "riseproject-dev/sample"}],
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "installation")
+        assert resp.status_code == 200
+
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "installation.created"
+    assert kwargs["outcome"] == "ok"
+    assert kwargs["installation_id"] == 999
+    assert kwargs["app_id"] == 2167633
+    assert kwargs["entity_id"] == 152654596
+    assert kwargs["account_login"] == "riseproject-dev"
+
+
+def test_webhook_installation_repositories_added_logs(_mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "added",
+        "installation": {"id": 999, "app_id": 2167633,
+                         "target_id": 152654596, "target_type": "Organization",
+                         "account": {"id": 152654596, "login": "riseproject-dev",
+                                     "type": "Organization"}},
+        "repositories_added": [{"id": 2, "full_name": "riseproject-dev/new-repo"}],
+        "repositories_removed": [],
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "installation_repositories")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "installation_repositories.added"
+
+
+def test_webhook_installation_target_renamed_logs(_mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "renamed",
+        "installation": {"id": 999, "app_id": 2167633,
+                         "target_id": 152654596, "target_type": "Organization",
+                         "account": {"id": 152654596, "login": "renamed-org",
+                                     "type": "Organization"}},
+        "changes": {"login": {"from": "riseproject-dev"}},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "installation_target")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "installation_target.renamed"
+    assert kwargs["account_login"] == "renamed-org"
+
+
+def test_webhook_unhandled_event_logs_ignored_event(_mock_add_installation_event):
+    from ghfe import app
+    body = json.dumps({"ref": "refs/heads/main"})
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "push")
+        assert resp.status_code == 200
+        assert b"Ignoring push event" in resp.data
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "push"
+    assert kwargs["outcome"] == "ignored_event"
+
+
+@patch("db.add_job", return_value=True)
+def test_webhook_workflow_job_queued_logs_job_stored(mock_add_job, _mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "queued",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"],
+                         "html_url": "https://github.com/o/r/actions/runs/1/job/12345"},
+        "repository": {"id": 100, "full_name": "riseproject-dev/sample",
+                       "owner": {"id": 152654596, "login": "riseproject-dev",
+                                 "type": "Organization"}},
+        "installation": {"id": 999},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "workflow_job.queued"
+    assert kwargs["outcome"] == "job_stored"
+
+
+@patch("db.add_job", return_value=False)
+def test_webhook_workflow_job_queued_already_exists(mock_add_job, _mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "queued",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"],
+                         "html_url": "https://github.com/o/r/actions/runs/1/job/12345"},
+        "repository": {"id": 100, "full_name": "riseproject-dev/sample",
+                       "owner": {"id": 152654596, "login": "riseproject-dev",
+                                 "type": "Organization"}},
+        "installation": {"id": 999},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["outcome"] == "job_already_exists"
+
+
+@patch("db.mark_job_running", return_value="pending")
+def test_webhook_workflow_job_in_progress_logs_marked_running(mock_mr, _mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "in_progress",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"], "runner_name": "rn"},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "workflow_job.in_progress"
+    assert kwargs["outcome"] == "job_marked_running"
+
+
+@patch("db.mark_job_running", return_value=None)
+def test_webhook_workflow_job_in_progress_not_found(mock_mr, _mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "in_progress",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"]},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["outcome"] == "job_not_found"
+
+
+@patch("db.mark_job_completed", return_value="running")
+def test_webhook_workflow_job_completed_logs_marked_completed(mock_mc, _mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "completed",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"]},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "workflow_job.completed"
+    assert kwargs["outcome"] == "job_marked_completed"
+
+
+def test_webhook_workflow_job_unknown_action_logs_ignored_action(_mock_add_installation_event):
+    """Verifies the action-whitelist removal from check_webhook_event: unknown
+    workflow_job actions like 'waiting' now reach the workflow_job branch and
+    log outcome='ignored_action' instead of being rejected wholesale."""
+    from ghfe import app
+    body = json.dumps({"action": "waiting", "workflow_job": {}, "repository": {}})
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "workflow_job.waiting"
+    assert kwargs["outcome"] == "ignored_action"
+
+
+def test_webhook_workflow_job_no_label_logs_ignored_no_label(_mock_add_installation_event):
+    from ghfe import app
+    payload = {
+        "action": "queued",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["unsupported-label"]},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+        assert b"missing required platform label" in resp.data
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["event"] == "workflow_job.queued"
+    assert kwargs["outcome"] == "ignored_no_label"
+
+
+@patch("db.add_job", return_value=True)
+def test_webhook_app_id_falls_back_to_hook_target_id(mock_add_job, _mock_add_installation_event):
+    """workflow_job payloads carry a stub installation {id, node_id} without
+    app_id. The header X-GitHub-Hook-Installation-Target-Id must populate
+    add_installation_event(app_id=...)."""
+    from ghfe import app
+    payload = {
+        "action": "queued",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"],
+                         "html_url": "https://example.com"},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 200
+    kwargs = _last_log_call(_mock_add_installation_event)
+    assert kwargs["app_id"] == 2167633  # from X-GitHub-Hook-Installation-Target-Id
+
+
+@patch("db.add_job", return_value=True)
+def test_webhook_logs_after_jobs_commit_even_when_log_raises(mock_add_job, _mock_add_installation_event):
+    """If add_installation_event raises, the side-effect (add_job) was already
+    called and committed in its own transaction. The webhook returns 500 and
+    GitHub retries; on retry add_job is a no-op via ON CONFLICT job_id."""
+    from ghfe import app
+    _mock_add_installation_event.side_effect = RuntimeError("DB hiccup")
+
+    payload = {
+        "action": "queued",
+        "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"],
+                         "html_url": "https://example.com"},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
+    }
+    body = json.dumps(payload)
+    with app.test_client() as client:
+        resp = _post_webhook(client, body, "workflow_job")
+        assert resp.status_code == 500
+    mock_add_job.assert_called_once()
+
+
+# --- /trace endpoints ---
+
+def _trace_get(client, path, token=TRACE_API_TOKEN):
+    headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
+    return client.get(path, headers=headers)
+
+
+def test_trace_entity_requires_bearer_token(_mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = client.get("/trace/entity/123")
+        assert resp.status_code == 401
+        resp = _trace_get(client, "/trace/entity/123", token="wrong")
+        assert resp.status_code == 401
+
+
+@patch("db.get_events_by_entity_id", return_value=[{"id": 1, "event": "installation.created"}])
+def test_trace_entity_returns_events(mock_get, _mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/entity/152654596")
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == "application/json"
+        data = json.loads(resp.data)
+        assert data == {"events": [{"id": 1, "event": "installation.created"}]}
+    mock_get.assert_called_once_with(152654596)
+
+
+@patch("db.get_events_by_entity_id", return_value=[{"id": 1}])
+@patch("db.get_entity_id_for_installation", return_value=152654596)
+def test_trace_installation_translates_to_entity(mock_get_eid, mock_get_events, _mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/installation/999")
+        assert resp.status_code == 200
+    mock_get_eid.assert_called_once_with(999)
+    mock_get_events.assert_called_once_with(152654596)
+
+
+@patch("db.get_entity_id_for_installation", return_value=None)
+def test_trace_installation_unknown_returns_empty(mock_get_eid, _mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/installation/999")
+        assert resp.status_code == 200
+        assert json.loads(resp.data) == {"events": []}
+
+
+@patch("db.get_entity_id_for_job", return_value=None)
+def test_trace_job_unknown_returns_empty(mock_get_eid, _mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/job/12345")
+        assert resp.status_code == 200
+        assert json.loads(resp.data) == {"events": []}
+
+
+@patch("db.get_events_by_entity_id", return_value=[{"id": 1}])
+@patch("db.get_entity_id_for_job", return_value=152654596)
+def test_trace_job_uses_one_hop_lookup(mock_get_eid, mock_get_events, _mock_add_installation_event):
+    """job_id -> entity_id direct via jobs.entity_id (one query)."""
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/job/12345")
+        assert resp.status_code == 200
+    mock_get_eid.assert_called_once_with(12345)
+    mock_get_events.assert_called_once_with(152654596)
+
+
+@patch("db.get_payload_by_id", return_value={"action": "created", "installation": {"id": 999}})
+def test_trace_payload_returns_payload_only(mock_get_payload, _mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/payload/42")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert set(data.keys()) == {"payload"}
+        assert data["payload"] == {"action": "created", "installation": {"id": 999}}
+    mock_get_payload.assert_called_once_with(42)
+
+
+@patch("db.get_payload_by_id", return_value=None)
+def test_trace_payload_not_found(mock_get_payload, _mock_add_installation_event):
+    from ghfe import app
+    with app.test_client() as client:
+        resp = _trace_get(client, "/trace/payload/42")
+        assert resp.status_code == 404

--- a/tests/test_ghfe.py
+++ b/tests/test_ghfe.py
@@ -312,7 +312,6 @@ def test_setup_upstream_error(mock_get_installation):
 # --- Installation event logging on the webhook handler ---
 
 DELIVERY_HEADERS = {
-    "X-GitHub-Delivery": "11111111-2222-3333-4444-555555555555",
     "X-GitHub-Hook-Installation-Target-Id": "2167633",
 }
 
@@ -384,7 +383,7 @@ def test_webhook_installation_created_logs(_mock_add_installation_event):
     assert kwargs["installation_id"] == 999
     assert kwargs["app_id"] == 2167633
     assert kwargs["entity_id"] == 152654596
-    assert kwargs["account_login"] == "riseproject-dev"
+    assert kwargs["entity_name"] == "riseproject-dev"
 
 
 def test_webhook_installation_repositories_added_logs(_mock_add_installation_event):
@@ -422,7 +421,7 @@ def test_webhook_installation_target_renamed_logs(_mock_add_installation_event):
         assert resp.status_code == 200
     kwargs = _last_log_call(_mock_add_installation_event)
     assert kwargs["event"] == "installation_target.renamed"
-    assert kwargs["account_login"] == "renamed-org"
+    assert kwargs["entity_name"] == "renamed-org"
 
 
 def test_webhook_unhandled_event_logs_ignored_event(_mock_add_installation_event):

--- a/tests/test_ghfe.py
+++ b/tests/test_ghfe.py
@@ -91,15 +91,11 @@ def test_match_labels_riscv():
 
 
 def test_match_labels_unsupported():
-    with pytest.raises(WebhookError) as exc:
-        match_labels_to_k8s(0, "", ["unsupported-label"])
-    assert "missing required platform label" in exc.value.message
+    assert match_labels_to_k8s(0, "", ["unsupported-label"]) is None
 
 
 def test_match_labels_missing_platform():
-    with pytest.raises(WebhookError) as exc:
-        match_labels_to_k8s(0, "", ["random-label"])
-    assert "missing required platform label" in exc.value.message
+    assert match_labels_to_k8s(0, "", ["random-label"]) is None
 
 
 # --- Webhook integration ---
@@ -189,6 +185,7 @@ def test_webhook_in_progress(mock_update):
         "action": "in_progress",
         "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"], "runner_name": "my-runner"},
         "repository": {"id": 100, "full_name": "riseproject-dev/sample", "owner": {"id": 152654596, "login": "riseproject-dev", "type": "Organization"}},
+        "installation": {"id": 999},
     }
     body = json.dumps(payload)
     sig = "sha256=" + compute_signature(body, GHAPP_WEBHOOK_SECRET).hexdigest()
@@ -214,6 +211,7 @@ def test_webhook_completed(mock_complete):
         "action": "completed",
         "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"], "runner_name": "my-runner"},
         "repository": {"id": 100, "full_name": "riseproject-dev/sample", "owner": {"id": 152654596, "login": "riseproject-dev", "type": "Organization"}},
+        "installation": {"id": 999},
     }
     body = json.dumps(payload)
     sig = "sha256=" + compute_signature(body, GHAPP_WEBHOOK_SECRET).hexdigest()
@@ -493,6 +491,7 @@ def test_webhook_workflow_job_in_progress_logs_marked_running(mock_mr, _mock_add
         "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"], "runner_name": "rn"},
         "repository": {"id": 100, "full_name": "o/r",
                        "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
     }
     body = json.dumps(payload)
     with app.test_client() as client:
@@ -511,6 +510,7 @@ def test_webhook_workflow_job_in_progress_not_found(mock_mr, _mock_add_installat
         "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"]},
         "repository": {"id": 100, "full_name": "o/r",
                        "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
     }
     body = json.dumps(payload)
     with app.test_client() as client:
@@ -528,6 +528,7 @@ def test_webhook_workflow_job_completed_logs_marked_completed(mock_mc, _mock_add
         "workflow_job": {"id": 12345, "name": "test", "labels": ["ubuntu-24.04-riscv"]},
         "repository": {"id": 100, "full_name": "o/r",
                        "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
     }
     body = json.dumps(payload)
     with app.test_client() as client:
@@ -543,7 +544,14 @@ def test_webhook_workflow_job_unknown_action_logs_ignored_action(_mock_add_insta
     workflow_job actions like 'waiting' now reach the workflow_job branch and
     log outcome='ignored_action' instead of being rejected wholesale."""
     from ghfe import app
-    body = json.dumps({"action": "waiting", "workflow_job": {}, "repository": {}})
+    payload = {
+        "action": "waiting",
+        "workflow_job": {},
+        "repository": {"id": 100, "full_name": "o/r",
+                       "owner": {"id": 152654596, "login": "o", "type": "Organization"}},
+        "installation": {"id": 999},
+    }
+    body = json.dumps(payload)
     with app.test_client() as client:
         resp = _post_webhook(client, body, "workflow_job")
         assert resp.status_code == 200

--- a/tests/test_ghfe.py
+++ b/tests/test_ghfe.py
@@ -98,6 +98,18 @@ def test_match_labels_missing_platform():
     assert match_labels_to_k8s(0, "", ["random-label"]) is None
 
 
+def test_match_labels_pytorch_org_no_match():
+    """PyTorch org with non-PyTorch labels → no match (covers the org-specific
+    no-match branch separately from the general-case fall-through)."""
+    from constants import PYTORCH_ORG_ID
+    assert match_labels_to_k8s(PYTORCH_ORG_ID, "", ["ubuntu-latest"]) is None
+
+
+def test_match_labels_ggml_org_no_match():
+    from constants import GGML_ORG_ORG_ID
+    assert match_labels_to_k8s(GGML_ORG_ORG_ID, "", ["ubuntu-latest"]) is None
+
+
 # --- Webhook integration ---
 
 @patch("db.add_job", return_value=True)

--- a/tests/test_ghfe.py
+++ b/tests/test_ghfe.py
@@ -122,6 +122,7 @@ def test_webhook_queued_stores_job(mock_store):
         resp = client.post("/", data=body, headers={
             "X-Hub-Signature-256": sig,
             "X-Github-Event": "workflow_job",
+            "X-GitHub-Hook-Installation-Target-Id": "2167633",
             "Content-Type": "application/json",
         })
         assert resp.status_code == 200
@@ -159,6 +160,7 @@ def test_webhook_queued_personal_account(mock_store):
         resp = client.post("/", data=body, headers={
             "X-Hub-Signature-256": sig,
             "X-Github-Event": "workflow_job",
+            "X-GitHub-Hook-Installation-Target-Id": "2167633",
             "Content-Type": "application/json",
         })
         assert resp.status_code == 200
@@ -195,6 +197,7 @@ def test_webhook_in_progress(mock_update):
         resp = client.post("/", data=body, headers={
             "X-Hub-Signature-256": sig,
             "X-Github-Event": "workflow_job",
+            "X-GitHub-Hook-Installation-Target-Id": "2167633",
             "Content-Type": "application/json",
         })
         assert resp.status_code == 200
@@ -219,6 +222,7 @@ def test_webhook_completed(mock_complete):
         resp = client.post("/", data=body, headers={
             "X-Hub-Signature-256": sig,
             "X-Github-Event": "workflow_job",
+            "X-GitHub-Hook-Installation-Target-Id": "2167633",
             "Content-Type": "application/json",
         })
         assert resp.status_code == 200
@@ -406,14 +410,17 @@ def test_webhook_installation_repositories_added_logs(_mock_add_installation_eve
 
 
 def test_webhook_installation_target_renamed_logs(_mock_add_installation_event):
+    """installation_target.renamed payload carries the new account at top
+    level; we record the new login (not the cached one in installation.account)."""
     from ghfe import app
     payload = {
         "action": "renamed",
-        "installation": {"id": 999, "app_id": 2167633,
-                         "target_id": 152654596, "target_type": "Organization",
-                         "account": {"id": 152654596, "login": "renamed-org",
-                                     "type": "Organization"}},
+        # Top-level account = new state. installation.account would be stale.
+        "account": {"id": 152654596, "login": "renamed-org", "type": "Organization"},
         "changes": {"login": {"from": "riseproject-dev"}},
+        "target_type": "Organization",
+        "installation": {"id": 999, "app_id": 2167633, "target_id": 152654596,
+                         "target_type": "Organization"},
     }
     body = json.dumps(payload)
     with app.test_client() as client:
@@ -422,6 +429,7 @@ def test_webhook_installation_target_renamed_logs(_mock_add_installation_event):
     kwargs = _last_log_call(_mock_add_installation_event)
     assert kwargs["event"] == "installation_target.renamed"
     assert kwargs["entity_name"] == "renamed-org"
+    assert kwargs["entity_id"] == 152654596
 
 
 def test_webhook_unhandled_event_logs_ignored_event(_mock_add_installation_event):
@@ -564,10 +572,10 @@ def test_webhook_workflow_job_no_label_logs_ignored_no_label(_mock_add_installat
 
 
 @patch("db.add_job", return_value=True)
-def test_webhook_app_id_falls_back_to_hook_target_id(mock_add_job, _mock_add_installation_event):
-    """workflow_job payloads carry a stub installation {id, node_id} without
-    app_id. The header X-GitHub-Hook-Installation-Target-Id must populate
-    add_installation_event(app_id=...)."""
+def test_webhook_app_id_comes_from_hook_target_id_header(mock_add_job, _mock_add_installation_event):
+    """`app_id` is always taken from X-GitHub-Hook-Installation-Target-Id —
+    this is the canonical signal of which app delivered the event, and is
+    set by GitHub on every App webhook."""
     from ghfe import app
     payload = {
         "action": "queued",
@@ -648,21 +656,21 @@ def test_trace_installation_translates_to_entity(mock_get_eid, mock_get_events, 
 
 
 @patch("db.get_entity_id_for_installation", return_value=None)
-def test_trace_installation_unknown_returns_empty(mock_get_eid, _mock_add_installation_event):
+def test_trace_installation_unknown_returns_404(mock_get_eid, _mock_add_installation_event):
     from ghfe import app
     with app.test_client() as client:
         resp = _trace_get(client, "/trace/installation/999")
-        assert resp.status_code == 200
-        assert json.loads(resp.data) == {"events": []}
+        assert resp.status_code == 404
+        assert b"Entity not found" in resp.data
 
 
 @patch("db.get_entity_id_for_job", return_value=None)
-def test_trace_job_unknown_returns_empty(mock_get_eid, _mock_add_installation_event):
+def test_trace_job_unknown_returns_404(mock_get_eid, _mock_add_installation_event):
     from ghfe import app
     with app.test_client() as client:
         resp = _trace_get(client, "/trace/job/12345")
-        assert resp.status_code == 200
-        assert json.loads(resp.data) == {"events": []}
+        assert resp.status_code == 404
+        assert b"Entity not found" in resp.data
 
 
 @patch("db.get_events_by_entity_id", return_value=[{"id": 1}])
@@ -695,3 +703,35 @@ def test_trace_payload_not_found(mock_get_payload, _mock_add_installation_event)
     with app.test_client() as client:
         resp = _trace_get(client, "/trace/payload/42")
         assert resp.status_code == 404
+        assert b"Payload not found" in resp.data
+
+
+def test_webhook_missing_hook_target_id_returns_400(_mock_add_installation_event):
+    """X-GitHub-Hook-Installation-Target-Id is the canonical app_id signal;
+    if it's missing we reject the request with 400 rather than guessing."""
+    from ghfe import app
+    body = json.dumps({"zen": "ok"})
+    sig = "sha256=" + compute_signature(body, GHAPP_WEBHOOK_SECRET).hexdigest()
+    with app.test_client() as client:
+        # Header omitted on purpose
+        resp = client.post("/", data=body, headers={
+            "X-Hub-Signature-256": sig,
+            "X-Github-Event": "ping",
+            "Content-Type": "application/json",
+        })
+        assert resp.status_code == 400
+        assert b"X-GitHub-Hook-Installation-Target-Id" in resp.data
+
+
+def test_webhook_invalid_hook_target_id_returns_400(_mock_add_installation_event):
+    from ghfe import app
+    body = json.dumps({"zen": "ok"})
+    sig = "sha256=" + compute_signature(body, GHAPP_WEBHOOK_SECRET).hexdigest()
+    with app.test_client() as client:
+        resp = client.post("/", data=body, headers={
+            "X-Hub-Signature-256": sig,
+            "X-Github-Event": "ping",
+            "X-GitHub-Hook-Installation-Target-Id": "not-an-int",
+            "Content-Type": "application/json",
+        })
+        assert resp.status_code == 400

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from constants import EntityType
+from constants import EntityType, GHAPP_ORG_ID, GHAPP_PERSONAL_ID
 from github import (
     GitHubAPIError,
     authenticate_app,
@@ -25,7 +25,7 @@ def test_authenticate_app_org(mock_private_key, requests_mock):
     )
 
     with patch("github.generate_jwt", return_value="fake-jwt"):
-        token = authenticate_app(12345, entity_type=EntityType.ORGANIZATION)
+        token = authenticate_app(12345, GHAPP_ORG_ID)
     assert token == "v1.test-token"
 
 
@@ -40,7 +40,7 @@ def test_authenticate_app_personal(mock_private_key, requests_mock):
     )
 
     with patch("github.generate_jwt", return_value="fake-jwt"):
-        token = authenticate_app(67890, entity_type=EntityType.USER)
+        token = authenticate_app(67890, GHAPP_PERSONAL_ID)
     assert token == "v1.personal-token"
 
 
@@ -56,8 +56,13 @@ def test_authenticate_app_failure(mock_private_key, requests_mock):
 
     with patch("github.generate_jwt", return_value="fake-jwt"):
         with pytest.raises(GitHubAPIError) as exc:
-            authenticate_app(12345, entity_type=EntityType.ORGANIZATION)
+            authenticate_app(12345, GHAPP_ORG_ID)
     assert exc.value.status_code == 401
+
+
+def test_authenticate_app_unknown_app_id():
+    with pytest.raises(ValueError):
+        authenticate_app(12345, 99999)
 
 
 # --- Runner groups ---

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2022,3 +2022,99 @@ def test_render_worker_failed_unversioned_treated_as_v1():
 
     assert not any(l.startswith("  Reason:") for l in lines)
     assert "  Container runner: exit=0  Completed" in lines
+
+
+# --- _gh_authenticate_app wrapper ---
+
+from scheduler import _gh_authenticate_app
+
+
+@patch("scheduler.db.add_installation_event")
+@patch("scheduler.gh.authenticate_app")
+def test_gh_authenticate_app_success_no_log(mock_auth, mock_log):
+    """Successful auth returns the token, never logs."""
+    mock_auth.return_value = "tok-abc"
+
+    token = _gh_authenticate_app(999, EntityType.ORGANIZATION,
+                                 entity_id=152654596, account_login="riseproject-dev")
+
+    assert token == "tok-abc"
+    mock_log.assert_not_called()
+
+
+@patch("scheduler.db.add_installation_event")
+@patch("scheduler.gh.authenticate_app")
+def test_gh_authenticate_app_404_logs_and_reraises(mock_auth, mock_log):
+    from github import GitHubAPIError
+    mock_auth.side_effect = GitHubAPIError(404, "Not Found")
+
+    with pytest.raises(GitHubAPIError):
+        _gh_authenticate_app(999, EntityType.ORGANIZATION,
+                             job_id=12345, repo_full_name="o/r",
+                             entity_id=152654596, account_login="o")
+
+    mock_log.assert_called_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["source"] == "scheduler"
+    assert kwargs["event"] == "auth_attempt.404"
+    assert kwargs["outcome"] == "auth_404"
+    assert kwargs["installation_id"] == 999
+    assert kwargs["entity_id"] == 152654596
+    assert kwargs["account_login"] == "o"
+    payload = kwargs["payload"]
+    assert payload["installation_id"] == 999
+    assert payload["http_status"] == 404
+    assert payload["repository"] == {"id": None, "full_name": "o/r"}
+    assert payload["workflow_job"] == {"id": 12345}
+
+
+@patch("scheduler.db.add_installation_event")
+@patch("scheduler.gh.authenticate_app")
+def test_gh_authenticate_app_other_error_logs_and_reraises(mock_auth, mock_log):
+    from github import GitHubAPIError
+    mock_auth.side_effect = GitHubAPIError(500, "boom")
+
+    with pytest.raises(GitHubAPIError):
+        _gh_authenticate_app(999, EntityType.USER,
+                             entity_id=660779, account_login="luhenry")
+
+    mock_log.assert_called_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["event"] == "auth_attempt.other_error"
+    assert kwargs["outcome"] == "auth_other_error"
+    payload = kwargs["payload"]
+    assert payload["http_status"] == 500
+    # entity_type=USER -> personal app id
+    from constants import GHAPP_PERSONAL_ID
+    assert payload["app_id"] == GHAPP_PERSONAL_ID
+
+
+@patch("scheduler.db.add_installation_event", side_effect=RuntimeError("DB hiccup"))
+@patch("scheduler.gh.authenticate_app")
+def test_gh_authenticate_app_swallows_log_failure(mock_auth, mock_log):
+    """If the log write fails, the original GitHubAPIError still propagates —
+    the auth failure is the higher-priority signal. The log failure is logged
+    but does not become a new exception type for callers to handle."""
+    from github import GitHubAPIError
+    mock_auth.side_effect = GitHubAPIError(404, "Not Found")
+
+    with pytest.raises(GitHubAPIError):
+        _gh_authenticate_app(999, EntityType.ORGANIZATION)
+
+
+# --- ttl_cache exception non-caching: documents library behaviour we rely on ---
+
+def test_ttl_cache_does_not_cache_exceptions():
+    from cachetools.func import ttl_cache
+    calls = {"n": 0}
+
+    @ttl_cache(maxsize=8, ttl=60)
+    def flaky(x):
+        calls["n"] += 1
+        raise RuntimeError("nope")
+
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            flaky(1)
+    # Each call invoked the underlying function — no cached exception.
+    assert calls["n"] == 3

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -103,7 +103,8 @@ def test_demand_match_provisions_org_job(mock_jit, mock_group, mock_auth, mock_p
 
     demand_match()
 
-    mock_auth.assert_called_once_with(999, entity_type=EntityType.ORGANIZATION)
+    from constants import GHAPP_ORG_ID
+    mock_auth.assert_called_once_with(999, GHAPP_ORG_ID)
     mock_group.assert_called_once()
     mock_jit.assert_called_once()
     mock_provision.assert_called_once()
@@ -125,7 +126,8 @@ def test_demand_match_provisions_personal_job(mock_jit_repo, mock_auth, mock_pro
 
     demand_match()
 
-    mock_auth.assert_called_once_with(999, entity_type=EntityType.USER)
+    from constants import GHAPP_PERSONAL_ID
+    mock_auth.assert_called_once_with(999, GHAPP_PERSONAL_ID)
     mock_jit_repo.assert_called_once()
     # Verify repo_full_name is passed
     call_args = mock_jit_repo.call_args

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2036,7 +2036,7 @@ def test_gh_authenticate_app_success_no_log(mock_auth, mock_log):
     mock_auth.return_value = "tok-abc"
 
     token = _gh_authenticate_app(999, EntityType.ORGANIZATION,
-                                 entity_id=152654596, account_login="riseproject-dev")
+                                 entity_id=152654596, entity_name="riseproject-dev")
 
     assert token == "tok-abc"
     mock_log.assert_not_called()
@@ -2051,7 +2051,7 @@ def test_gh_authenticate_app_404_logs_and_reraises(mock_auth, mock_log):
     with pytest.raises(GitHubAPIError):
         _gh_authenticate_app(999, EntityType.ORGANIZATION,
                              job_id=12345, repo_full_name="o/r",
-                             entity_id=152654596, account_login="o")
+                             entity_id=152654596, entity_name="o")
 
     mock_log.assert_called_once()
     kwargs = mock_log.call_args.kwargs
@@ -2060,7 +2060,7 @@ def test_gh_authenticate_app_404_logs_and_reraises(mock_auth, mock_log):
     assert kwargs["outcome"] == "auth_404"
     assert kwargs["installation_id"] == 999
     assert kwargs["entity_id"] == 152654596
-    assert kwargs["account_login"] == "o"
+    assert kwargs["entity_name"] == "o"
     payload = kwargs["payload"]
     assert payload["installation_id"] == 999
     assert payload["http_status"] == 404
@@ -2076,7 +2076,7 @@ def test_gh_authenticate_app_other_error_logs_and_reraises(mock_auth, mock_log):
 
     with pytest.raises(GitHubAPIError):
         _gh_authenticate_app(999, EntityType.USER,
-                             entity_id=660779, account_login="luhenry")
+                             entity_id=660779, entity_name="luhenry")
 
     mock_log.assert_called_once()
     kwargs = mock_log.call_args.kwargs


### PR DESCRIPTION
## Summary
This PR adds comprehensive event logging for GitHub App installation lifecycle events and authentication failures, along with read-only trace endpoints to help debug "installation not found" issues. The system now records all webhook deliveries and scheduler auth attempts in an append-only `installation_events` table, enabling operators to reconstruct the history of an installation or entity.

## Key Changes

### Database Schema
- Added `installation_events` table to store webhook deliveries and scheduler auth attempts with:
  - Event type, outcome, and source (webhook/scheduler)
  - Installation, app, and entity identifiers
  - Full payload as JSONB for context
  - Indexes on `installation_id`, `account_login`, and `entity_id` for efficient querying
- Added `event_source_enum` and `entity_type_enum` PostgreSQL types

### Webhook Handler (`ghfe.py`)
- Removed action whitelist from `check_webhook_event()` — now all webhook events reach the handler and are logged with appropriate outcomes
- Added `_log_webhook_event()` helper to insert installation_events rows with extracted installation/account metadata
- Extended webhook handler to process and log:
  - `ping` events
  - `installation.*` events (created, deleted, suspended, etc.)
  - `installation_repositories.*` events (added, removed)
  - `installation_target.*` events (renamed)
  - `workflow_job.*` events with outcome tracking (job_stored, job_already_exists, job_marked_running, job_not_found, job_marked_completed, ignored_action, ignored_no_label)
- Falls back to `X-GitHub-Hook-Installation-Target-Id` header for `app_id` when payload lacks it (workflow_job deliveries)
- Logs are written in a separate transaction after side-effects (add_job, mark_job_*) to ensure GitHub retries are idempotent

### Scheduler Auth Logging (`scheduler.py`)
- Added `_gh_authenticate_app()` wrapper around `gh.authenticate_app()` that logs all failures to installation_events
- Logs `auth_attempt.404` and `auth_attempt.other_error` events with synthetic payloads containing installation, job, and repository context
- Successful authentications are not logged (cache hit optimization)
- Swallows log write failures to preserve the original GitHubAPIError for caller handling

### Database Helpers (`db.py`)
- `add_installation_event()`: Insert event row, returns BIGSERIAL id
- `get_events_by_entity_id()`: Fetch all events for an entity with workflow_job metadata extracted to columns (job_id, repo_full_name) for readability
- `get_payload_by_id()`: Fetch full JSONB payload for one event
- `get_entity_id_for_job()`: Lookup entity_id from jobs table
- `get_entity_id_for_installation()`: Lookup entity_id from installation_events with fallback to jobs table

### Trace Endpoints (`ghfe.py`)
- `/trace/entity/<entity_id>` — list all events for an entity
- `/trace/installation/<installation_id>` — list all events for an installation (resolves to entity)
- `/trace/job/<job_id>` — list all events for a job (resolves to entity)
- `/trace/payload/<event_id>` — fetch full JSONB payload for one event
- All endpoints require `Authorization: Bearer <TRACE_API_TOKEN>` header (401 if missing/wrong)

### Debugging Tool (`scripts/trace_installation.py`)
- New CLI tool to reconstruct installation history from production
- Supports lookup by `--installation-id`, `--entity-id`, `--entity-name` (resolved via `gh api`), or `--job-id`
- Renders chronological table with event, outcome, repo, job_id, and delivery_id columns
- `--verbose` flag dumps full payloads for `auth_attempt.*` rows
- `--json` flag outputs raw events as JSON
- Includes heuristic diagnosis hints (suspended, deleted, renamed, auth_404 events)

### Tests
- Removed old `check_webhook_event()` unit

https://claude.ai/code/session_01P4oRj3j7qwnLbYJ1KZSDEQ